### PR TITLE
[Sage] Clarify paper scope: ML techniques as focus, analytical as baselines

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -49,13 +49,14 @@
 
 \begin{abstract}
 Machine learning-based performance modeling has emerged as a powerful alternative to traditional analytical models and cycle-accurate simulators for predicting computer system behavior.
-This survey comprehensively analyzes ML techniques for performance prediction across CPUs, GPUs, accelerators, and distributed systems, covering over 60 papers from architecture and ML venues published between 2016--2025.
-We propose an eight-dimension taxonomy organizing approaches by modeling technique, target hardware, workload types, prediction targets, accuracy metrics, input requirements, evaluation scope, and reproducibility.
-Our analysis reveals that specialized models achieve remarkable accuracy---below 5\% error for narrow domains---while general-purpose models trade accuracy for broader applicability.
+This survey focuses specifically on \emph{ML techniques} for performance prediction across CPUs, GPUs, accelerators, and distributed systems, covering over 60 papers from architecture and ML venues published between 2016--2025.
+We position traditional analytical models (Timeloop, MAESTRO) and simulators (gem5, GPGPU-Sim) as \emph{baselines} that ML approaches aim to replace or augment.
+We propose an eight-dimension taxonomy organizing ML approaches by modeling technique, target hardware, workload types, prediction targets, accuracy metrics, input requirements, evaluation scope, and reproducibility.
+Our analysis reveals that specialized ML models achieve remarkable accuracy---below 5\% error for narrow domains---while general-purpose models trade accuracy for broader applicability.
 Transfer learning and meta-learning techniques increasingly enable adaptation to new hardware with minimal profiling, addressing the challenge of hardware diversity.
 We identify key open challenges including benchmark diversity, cross-platform generalization, and integration with compiler and architecture exploration workflows.
-Hybrid approaches combining analytical structure with learned components represent a promising direction, offering both interpretability and accuracy.
-This survey provides practitioners guidance for selecting appropriate techniques and researchers a roadmap for advancing the field.
+Hybrid approaches combining analytical structure with learned components represent the most promising direction, offering both interpretability and accuracy.
+This survey provides practitioners guidance for selecting appropriate ML techniques and researchers a roadmap for advancing the field.
 \end{abstract}
 
 %%
@@ -86,11 +87,12 @@ Recent work demonstrates remarkable accuracy: NeuSight~\cite{neusight2025} achie
 Beyond accuracy, these approaches offer practical benefits: models trained on one platform can transfer to new hardware with minimal adaptation~\cite{litepred2024}, and inference-time predictions complete in milliseconds rather than hours.
 
 This survey provides a comprehensive analysis of ML-based performance modeling techniques for computer architecture.
+We focus specifically on \emph{learned} models that acquire predictive capability from data, positioning traditional analytical and simulation approaches as baselines that contextualize ML advances.
 We make the following contributions:
 \begin{itemize}
-    \item A \textbf{taxonomy} organizing approaches along eight dimensions: modeling technique, target hardware, workload types, prediction targets, accuracy metrics, input requirements, evaluation scope, and reproducibility.
-    \item A \textbf{systematic survey} of over 60 papers from architecture venues (MICRO, ISCA, HPCA, ASPLOS) and ML venues (MLSys, NeurIPS, ICML) published between 2016--2025.
-    \item A \textbf{comparative analysis} examining trade-offs between accuracy, training cost, generalization, and interpretability across approaches.
+    \item A \textbf{taxonomy} organizing ML approaches along eight dimensions: modeling technique, target hardware, workload types, prediction targets, accuracy metrics, input requirements, evaluation scope, and reproducibility.
+    \item A \textbf{systematic survey} of over 60 ML-based performance modeling papers from architecture venues (MICRO, ISCA, HPCA, ASPLOS) and ML venues (MLSys, NeurIPS, ICML) published between 2016--2025.
+    \item A \textbf{comparative analysis} examining trade-offs between accuracy, training cost, generalization, and interpretability across ML approaches.
     \item An identification of \textbf{open challenges} including data scarcity, cross-platform generalization, and integration with design automation flows.
 \end{itemize}
 
@@ -112,8 +114,8 @@ Section~\ref{sec:conclusion} concludes.
 \subsection{Traditional Performance Modeling}
 \label{subsec:traditional-modeling}
 
-Performance modeling has traditionally relied on two complementary approaches: analytical models and cycle-accurate simulation.
-This section reviews both paradigms and their limitations, motivating the emergence of ML-based alternatives.
+Before ML-based approaches, performance modeling relied on two complementary paradigms: analytical models and cycle-accurate simulation.
+This section reviews both as \emph{baselines} against which ML techniques are compared, identifying their limitations that motivate learned alternatives.
 
 \subsubsection{Analytical Models}
 


### PR DESCRIPTION
## Summary
- Clarifies that ML techniques are the survey focus, not analytical/simulation tools
- Positions Timeloop, MAESTRO, gem5, etc. explicitly as *baselines* for comparison
- Minor text edits in abstract, introduction, and background section

## Changes
- `paper/main.tex`: Updated framing language in 3 locations

## Reviewer Feedback Addressed
- Issue #69 (W2): Title promises 'ML Approaches' but includes non-ML tools
- Issue #72: Title and scope mismatch

The paper structure remains unchanged; this is purely positioning clarification to help readers understand why analytical tools appear (as baselines, not as ML approaches).

## Test plan
- [ ] Paper compiles without errors
- [ ] Abstract clearly states ML focus
- [ ] Background section frames traditional approaches as baselines

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)