### PR TITLE
[Sage] Add NeuSight to Table VII and accuracy comparability note

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -935,6 +935,8 @@ VIDUR~\cite{vidur2024} & $<$5\% & Kernel profiles & Per-model & LLM-specific & H
 \end{tabular}
 \end{table*}
 
+\noindent\textit{Note: Accuracy figures in Tables I--III are reported as stated in original papers. Direct comparison across works is limited by differences in benchmarks, workloads, hardware targets, and evaluation protocols. Readers should consult original publications for methodology details.}
+
 \subsection{Accuracy vs. Training Cost}
 \label{subsec:accuracy-cost}
 
@@ -1258,6 +1260,7 @@ Timeloop & 3 & 4 & 2 & 9/10 \\
 ASTRA-sim & 1 & 2.5 & 3 & 6.5/10 \\
 VIDUR & 1.5 & 2 & 3 & 6.5/10 \\
 nn-Meter & 2 & 0 & 1 & 3/10 \\
+NeuSight & 2 & 3 & 2.5 & 7.5/10 \\
 \bottomrule
 \end{tabular}
 \end{table}


### PR DESCRIPTION
## Summary
- Adds NeuSight to Table VII (evaluation-summary) with reproducibility scores based on Section 7 evaluation text
- Adds note after Table III clarifying that accuracy metrics across papers are not directly comparable

## Details
**NeuSight Scoring Rationale (7.5/10):**
- Setup (2/3): Python + PyTorch/CUDA, GPU required for calibration
- Reproducibility (3/4): Good methodology description, hybrid approach provides robustness
- Usability (2.5/3): Pre-trained models expected, clear API

**Accuracy Note:**
Added italicized note acknowledging that accuracy figures are reported as stated in original papers and direct comparison is limited by different evaluation protocols.

## Test plan
- [ ] Verify LaTeX compiles correctly
- [ ] Confirm NeuSight row appears in Table VII
- [ ] Confirm accuracy note appears after Table III

Closes #106
Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)