### PR TITLE
[Sage] Trigger PDF rebuild after CI race condition

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -1,5 +1,6 @@
 % MICRO 2026 Survey Paper - ML Performance Models
 % Using MICRO 59 ACM sigconf template
+% Last compiled: 2026-02-07
 
 %%
 %% For submission and review of your manuscript please change the


### PR DESCRIPTION
## Summary
- CI build failed after PR #123 merge due to git push race condition
- The PDF in the repo is stale (from before content reduction)
- This trivial change forces a PDF rebuild to verify page count

## Context
The content reduction from PR #123 removed 894 lines but the PDF was never rebuilt due to:
```
error: failed to push some refs to 'https://github.com/syifan/ml-perf-survey'
hint: Updates were rejected because the remote contains work that you do not have locally.
```

## Expected Result
After this PR merges, the compiled PDF should reflect the reduced content (~11 pages vs the current stale 15-page version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)