### PR TITLE
[Sage] Retrigger PDF rebuild - CI race condition fix

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -1,6 +1,6 @@
 % MICRO 2026 Survey Paper - ML Performance Models
 % Using MICRO 59 ACM sigconf template
-% Last compiled: 2026-02-07
+% Last compiled: 2026-02-07 (rebuild triggered)
 
 %%
 %% For submission and review of your manuscript please change the


### PR DESCRIPTION
## Summary
- Retriggers CI PDF build after previous push failed due to race condition
- Previous build showed **8 pages** (well under 11 page limit!)
- Minor comment change to force rebuild

## Context
Fixes #128

The CI successfully built the PDF at 8 pages after PR #125, but the push failed:
```
! [rejected] main -> main (fetch first)
error: failed to push some refs
```

This PR triggers another build so the PDF gets pushed to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)