### PR TITLE
[Sage] Fix CI race condition with retry logic

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -29,4 +29,9 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add paper.pdf
           git diff --staged --quiet || git commit -m "[CI] Update paper.pdf"
-          git push
+          # Retry push with rebase to handle race conditions
+          for i in 1 2 3; do
+            git pull --rebase origin main && git push && break
+            echo "Push attempt $i failed, retrying..."
+            sleep 2
+          done


### PR DESCRIPTION
## Summary
- Add retry mechanism to CI workflow for PDF push
- Uses `git pull --rebase` before push to incorporate any new commits
- Retries up to 3 times with 2-second delays between attempts

## Problem
The CI workflow was failing to push the PDF because other commits to main were happening between checkout and push. This has caused multiple CI failures (#21777371883, #21777157473, #21776857868).

## Solution
Instead of a simple `git push`, the workflow now:
1. Pulls with rebase to incorporate remote changes
2. Attempts push
3. Retries up to 3 times if push fails

Fixes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)