### PR TITLE
[Sage] Fix paper count claim and add threats to validity section

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -50,7 +50,7 @@
 
 \begin{abstract}
 Machine learning-based performance modeling has emerged as a powerful alternative to traditional analytical models and cycle-accurate simulators for predicting computer system behavior.
-This survey focuses specifically on \emph{ML techniques} for performance prediction across CPUs, GPUs, accelerators, and distributed systems, covering over 60 papers from architecture and ML venues published between 2016--2026.
+This survey focuses specifically on \emph{ML techniques} for performance prediction across CPUs, GPUs, accelerators, and distributed systems, covering over 50 papers from architecture and ML venues published between 2016--2026.
 We position traditional analytical models (Timeloop, MAESTRO) and simulators (gem5, GPGPU-Sim) as \emph{baselines} that ML approaches aim to replace or augment.
 We organize ML approaches along three primary dimensions---modeling technique, target hardware, and input representation---while additionally characterizing papers by workload coverage, prediction targets, accuracy metrics, and evaluation scope.
 Our analysis reveals that specialized ML models achieve remarkable accuracy---below 5\% error for narrow domains---while general-purpose models trade accuracy for broader applicability.
@@ -92,7 +92,7 @@ We focus specifically on \emph{learned} models that acquire predictive capabilit
 We make the following contributions:
 \begin{itemize}
     \item A \textbf{taxonomy} organizing ML approaches along three primary dimensions (modeling technique, target hardware, input representation), with additional characterization by workload coverage, prediction targets, and accuracy.
-    \item A \textbf{systematic survey} of over 60 ML-based performance modeling papers from architecture venues (MICRO, ISCA, HPCA, ASPLOS) and ML venues (MLSys, NeurIPS, ICML) published between 2016--2026.
+    \item A \textbf{systematic survey} of over 50 ML-based performance modeling papers from architecture venues (MICRO, ISCA, HPCA, ASPLOS) and ML venues (MLSys, NeurIPS, ICML) published between 2016--2026.
     \item A \textbf{comparative analysis} examining trade-offs between accuracy, training cost, generalization, and interpretability across ML approaches.
     \item An identification of \textbf{open challenges} including data scarcity, cross-platform generalization, and integration with design automation flows.
 \end{itemize}
@@ -686,6 +686,24 @@ Five high-priority gaps:
 (4) \textbf{Unified energy-latency-memory prediction}---ML approaches focus on latency while edge/datacenter need energy.
 (5) \textbf{Temporal robustness benchmarks}---no systematic evaluation of robustness to software evolution.
 
+\subsection{Threats to Validity}
+\label{subsec:threats}
+
+We acknowledge several limitations of this survey.
+
+\textbf{Selection bias.}
+Our literature search focused on top architecture venues (MICRO, ISCA, HPCA, ASPLOS) and ML systems venues (MLSys, OSDI, SOSP), which may under-represent work published in application-specific venues, industry reports, or non-English publications.
+We prioritized papers with publicly available implementations or detailed methodological descriptions, potentially biasing toward better-documented approaches.
+
+\textbf{Tool evaluation scope.}
+Our reproducibility evaluation covers five representative tools (Timeloop, ASTRA-sim, VIDUR, nn-Meter, NeuSight), which cannot fully represent the diversity of available approaches.
+Tool selection prioritized coverage across taxonomy dimensions (analytical, simulation, ML-based) and availability of open-source implementations.
+Results may not generalize to proprietary or unpublished tools.
+
+\textbf{Metrics comparability.}
+Accuracy figures reported across papers use different metrics (MAPE, RMSE, correlation coefficients), benchmarks, and hardware targets, limiting direct comparison.
+Table~\ref{tab:comparison-summary} reports metrics as stated in original papers; readers should interpret cross-paper comparisons with caution.
+
 \subsection{Future Work: Toward Unified Tooling}
 \label{subsec:unified-architecture}
 
@@ -738,7 +756,7 @@ Projects should prefer portable formats (ONNX) or pin exact dependency versions.
 \section{Conclusion}
 \label{sec:conclusion}
 
-This survey analyzed over 60 papers on ML-based performance modeling for computer architecture.
+This survey analyzed over 50 papers on ML-based performance modeling for computer architecture.
 
 \textbf{Key findings:}
 (1) ML models achieve $<$5\% error on target domains (NeuSight 2.3\%, LitePred 0.7\%).


### PR DESCRIPTION
## Summary
- Fixed inaccurate "over 60 papers" claim → "over 50 papers" to match bibliography (~51 entries)
- Added Threats to Validity subsection addressing Crit's review feedback

## Changes
1. **Paper count fix** (abstract, introduction, conclusion): Changed from "over 60" to "over 50" papers
2. **Threats to Validity section** (~0.5 page) covering:
   - Selection bias in literature search methodology
   - Tool evaluation scope limitations (5 representative tools)
   - Metrics comparability limitations across papers

## Related Issues
Fixes #133 (paper count claim)
Fixes #135 (threats to validity)

## Test Plan
- [ ] Verify LaTeX compiles without errors
- [ ] Review wording for technical accuracy
- [ ] Confirm threats section addresses Crit's review concerns

🤖 Generated with [Claude Code](https://claude.com/claude-code)