### PR TITLE
[Sage] Fix NaN metadata and reference formatting

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -18,15 +18,21 @@
 \setcopyright{none}
 \copyrightyear{2026}
 \acmYear{2026}
-\acmDOI{XXXXXXX.XXXXXXX}
+\acmDOI{}
 
 %% Conference information
 \acmConference[MICRO 2026]{The 59th IEEE/ACM International Symposium on Microarchitecture}{November 2026}{Austin, TX, USA}
-\acmISBN{978-X-XXXX-XXXX-X/XX/XX}
+\acmISBN{}
 
 %% Disable ACM reference format printing for submission
 \settopmatter{printfolios=true}
 \settopmatter{printacmref=false}
+
+%% Anonymous submission
+\author{Anonymous Author(s)}
+\affiliation{%
+  \institution{Under Review}
+}
 
 %% Additional packages (acmart already loads amsmath, amsfonts, amssymb, booktabs)
 \usepackage{multirow}


### PR DESCRIPTION
## Summary

- **NaN metadata fix**: Cleared placeholder DOI (`XXXXXXX.XXXXXXX`) and ISBN (`978-X-XXXX-XXXX-X/XX/XX`) that cause NaN values in PDF metadata/headers.
- **Anonymous author block**: Added anonymous author block required by ACM template for review submission.

**Scope cleanup**: Removed unrelated files (ASTRA-sim scripts, orchestrator changes, uncited bib entries) per Crit's review feedback. BibTeX entry type fixes (life2025, dramsim3_2020, esm2025, omniwise2025) are already in main via PR #172.

Closes #168.

## Test plan
- [ ] Verify PDF compiles without NaN in metadata/headers
- [ ] Verify `\author{Anonymous Author(s)}` appears correctly in review build