### PR TITLE
Fix abstract tool count claim (~25 tools)

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -61,7 +61,7 @@
 \begin{abstract}
 As machine learning workloads grow in scale and complexity---spanning training and inference for CNNs, transformers, mixture-of-experts models, and LLMs---architects and system designers need fast, accurate methods to predict their performance across diverse hardware platforms.
 This survey provides a comprehensive analysis of the tools and methods available for modeling and simulating the performance of ML workloads, covering analytical models, cycle-accurate simulators, trace-driven approaches, and ML-augmented hybrid techniques.
-We survey over 30 tools drawn from 53 papers across architecture venues (MICRO, ISCA, HPCA, ASPLOS) and systems venues (MLSys, OSDI, NSDI) published between 2016--2026, spanning DNN accelerator modeling (Timeloop, MAESTRO, Sparseloop), GPU simulation (GPGPU-Sim, Accel-Sim, NeuSight), distributed training simulation (ASTRA-sim, Lumos, SimAI), and LLM inference serving (VIDUR, Frontier, AMALI).
+We survey approximately 25 tools drawn from 53 papers across architecture venues (MICRO, ISCA, HPCA, ASPLOS) and systems venues (MLSys, OSDI, NSDI) published between 2016--2026, spanning DNN accelerator modeling (Timeloop, MAESTRO, Sparseloop), GPU simulation (GPGPU-Sim, Accel-Sim, NeuSight), distributed training simulation (ASTRA-sim, Lumos, SimAI), and LLM inference serving (VIDUR, Frontier, AMALI).
 We organize the literature along three dimensions---methodology type (analytical, simulation, ML-augmented, hybrid), target platform (accelerators, GPUs, distributed systems, edge devices), and abstraction level (kernel, model, system)---while additionally characterizing tools by workload coverage, revealing a pervasive CNN-validation bias.
 Our analysis reveals that hybrid approaches combining analytical structure with learned components achieve the best accuracy-speed trade-offs, while pure analytical models offer superior interpretability for design space exploration.
 We conduct hands-on reproducibility evaluations of five representative tools, finding that reproducibility varies dramatically: Docker-first tools score 8.5+/10 on our rubric while tools relying on serialized ML models risk becoming unusable.
@@ -641,7 +641,7 @@ Five priorities: (1)~transformer/MoE-aware tools with validated non-CNN accuracy
 \section{Conclusion}
 \label{sec:conclusion}
 
-This survey analyzed over 30 tools for predicting ML workload performance.
+This survey analyzed approximately 25 tools for predicting ML workload performance.
 Key findings: methodology determines trade-offs (analytical: fast + interpretable; hybrid: best accuracy--speed balance at 2.3\% MAPE); LLM workloads demand purpose-built tools (VIDUR, Frontier); and Docker-first deployment is the strongest reproducibility predictor (8.5+/10 vs.\ 3/10 without).
 The most pressing gaps are CNN-to-transformer generalization, kernel-to-end-to-end error composition, and emerging hardware support.
 


### PR DESCRIPTION
## Summary
- Updates "over 30 tools" to "approximately 25 tools" in both the abstract and conclusion
- The main taxonomy table (Table 4) lists 22 primary tools; ~14 additional tools are mentioned in passing in the body text
- "Approximately 25" accurately reflects the number of tools that are substantively surveyed

Fixes issue #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)