### PR TITLE
Strategic content expansion for 10.5-11 page target

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -102,7 +102,66 @@ We make the following contributions:
 
 The paper proceeds as follows: Section~\ref{sec:methodology} describes our methodology; Section~\ref{sec:background} provides background; Section~\ref{sec:taxonomy} presents the taxonomy; Section~\ref{sec:survey} surveys tools by platform; Section~\ref{sec:comparison} compares accuracy and provides tool selection guidance; Section~\ref{sec:evaluation} presents reproducibility evaluations; Section~\ref{sec:challenges} discusses open challenges; and Section~\ref{sec:conclusion} concludes.
 
-The field has evolved from early analytical frameworks (Eyeriss~\cite{eyeriss2016}, Paleo~\cite{paleo2017}) through systematic accelerator modeling (Timeloop~\cite{timeloop2019}, MAESTRO~\cite{maestro2019}) and distributed training simulation (ASTRA-sim~\cite{astrasim2020}), to modern hybrid analytical+learned approaches (NeuSight~\cite{neusight2025}) and LLM-specific modeling (VIDUR~\cite{vidur2024}, Frontier~\cite{frontier2025}); Table~\ref{tab:survey-summary} provides a comprehensive chronological overview.
+Figure~\ref{fig:timeline} illustrates the evolution of performance modeling tools for ML workloads, from early analytical frameworks through simulators to modern hybrid approaches.
+
+\begin{figure}[t]
+\centering
+\resizebox{\columnwidth}{!}{%
+\begin{tikzpicture}[
+    node distance=0.3cm,
+    yearnode/.style={font=\footnotesize\bfseries, text=black!70},
+    eventnode/.style={font=\scriptsize, text width=2.8cm, align=center},
+    catnode/.style={font=\tiny, text=white, rounded corners=1pt, inner sep=2pt}
+]
+% Timeline base
+\draw[thick, ->, black!40] (0,0) -- (14.5,0);
+
+% Year markers
+\foreach \x/\year in {0.5/2016, 2.5/2018, 4.5/2020, 6.5/2022, 8.5/2024, 10.5/2025, 12.5/2026} {
+    \draw[thick, black!40] (\x,-0.15) -- (\x,0.15);
+    \node[yearnode, below] at (\x,-0.2) {\year};
+}
+
+% Events - staggered heights to avoid overlap
+\node[eventnode, above] at (0.5,0.4) {Eyeriss~\cite{eyeriss2016}\\Paleo~\cite{paleo2017}};
+\node[catnode, fill=blue!60] at (0.5,1.2) {ISCA/ICLR};
+
+\node[eventnode, below] at (2.0,-0.4) {TVM~\cite{tvm2018}\\(compiler cost)};
+\node[catnode, fill=green!50!black] at (2.0,-1.1) {OSDI};
+
+\node[eventnode, above] at (3.0,0.4) {Timeloop~\cite{timeloop2019}\\MAESTRO~\cite{maestro2019}};
+\node[catnode, fill=blue!60] at (3.0,1.2) {ISPASS/MICRO};
+
+\node[eventnode, below] at (4.5,-0.4) {Ansor~\cite{ansor2020}\\ASTRA-sim~\cite{astrasim2020}};
+\node[catnode, fill=green!50!black] at (4.5,-1.1) {OSDI/ISPASS};
+
+\node[eventnode, above] at (5.5,0.4) {nn-Meter~\cite{nnmeter2021}\\Habitat~\cite{habitat2021}};
+\node[catnode, fill=orange!70] at (5.5,1.2) {MobiSys/ATC};
+
+\node[eventnode, below] at (6.5,-0.4) {Sparseloop~\cite{sparseloop2022}\\Accel-Sim~\cite{accelsim2020}};
+\node[catnode, fill=blue!60] at (6.5,-1.1) {MICRO/ISCA};
+
+\node[eventnode, above] at (7.5,0.4) {TLP~\cite{tlp2023}\\ASTRA-sim 2.0~\cite{astrasim2023}};
+\node[catnode, fill=purple!60] at (7.5,1.2) {ASPLOS/ISPASS};
+
+\node[eventnode, below] at (8.8,-0.4) {VIDUR~\cite{vidur2024}\\Splitwise~\cite{splitwise2024}};
+\node[catnode, fill=red!60] at (8.8,-1.1) {MLSys/ISCA};
+
+\node[eventnode, above] at (10.5,0.4) {NeuSight~\cite{neusight2025}\\AMALI~\cite{amali2025}};
+\node[catnode, fill=purple!60] at (10.5,1.2) {ASPLOS/ISCA};
+
+\node[eventnode, below] at (12.5,-0.4) {Frontier~\cite{frontier2025}\\Lumos~\cite{lumos2025}};
+\node[catnode, fill=red!60] at (12.5,-1.1) {MLSys};
+
+% Trend arrow
+\draw[thick, ->, blue!50, dashed] (1,1.6) -- (12,1.6);
+\node[font=\scriptsize, text=blue!60, above] at (6.5,1.6) {Toward hybrid analytical+learned models};
+
+\end{tikzpicture}
+}
+\caption{Evolution of performance modeling tools for ML workloads (2016--2026). Early analytical frameworks (Eyeriss, Paleo) gave way to systematic accelerator modeling (Timeloop, MAESTRO) and distributed training simulation (ASTRA-sim). Recent work targets LLM-specific modeling (VIDUR, Frontier) and hybrid analytical+learned approaches (NeuSight).}
+\label{fig:timeline}
+\end{figure}
 
 % ==============================================================================
 % SURVEY METHODOLOGY
@@ -199,12 +258,26 @@ The trade-off columns further show that methodologies cluster into two speed reg
 \subsection{Primary Axis: Methodology Type}
 \label{subsec:by-methodology}
 
-The choice of methodology determines fundamental trade-offs (Table~\ref{tab:taxonomy-matrix}); Section~\ref{sec:survey} provides detailed per-tool analysis.
-\textbf{Analytical models} express performance as closed-form functions, offering microsecond evaluation and full interpretability but requiring per-architecture derivation (e.g., Timeloop~\cite{timeloop2019}: 5--10\% error at 2000$\times$ speedup).
-\textbf{Cycle-accurate simulators} (GPGPU-Sim~\cite{gpgpusim2009}, Accel-Sim~\cite{accelsim2020}) achieve high fidelity at $1000$--$10000\times$ slowdown, impractical for DSE.
-\textbf{Trace-driven simulators} replay execution traces for system-level modeling (ASTRA-sim~\cite{astrasim2023}: 5--15\% error; VIDUR~\cite{vidur2024}: $<$5\%), with some using ML internally.
-\textbf{ML-augmented models} learn from profiling data (nn-Meter~\cite{nnmeter2021}, TVM~\cite{tvm2018}), but suffer from \emph{silent distribution shift}.
-\textbf{Hybrid} approaches combine analytical structure with learned residuals (NeuSight~\cite{neusight2025}: 2.3\% MAPE), achieving the best accuracy--speed trade-offs; transfer learning provides 22.5\% average improvement~\cite{latencypredictorsnas2024}.
+The choice of methodology determines fundamental trade-offs between accuracy, evaluation speed, data requirements, and interpretability, as summarized in Table~\ref{tab:taxonomy-matrix}; Section~\ref{sec:survey} provides detailed per-tool analysis.
+
+\textbf{Analytical models} express performance as closed-form functions of workload and hardware parameters.
+Timeloop~\cite{timeloop2019} achieves 5--10\% error versus RTL at 2000$\times$ speedup for DNN accelerators; MAESTRO~\cite{maestro2019} and Sparseloop~\cite{sparseloop2022} extend to data-centric directives and sparse tensors; Paleo~\cite{paleo2017} and AMALI~\cite{amali2025} target distributed training and GPU LLM inference, respectively.
+These models provide microsecond evaluation and full interpretability but require per-architecture derivation and may miss dynamic effects (AMALI's 23.6\% MAPE illustrates this ceiling for GPUs).
+
+\textbf{Cycle-accurate simulators} model hardware at register-transfer level.
+GPGPU-Sim~\cite{gpgpusim2009} and Accel-Sim~\cite{accelsim2020} achieve 0.90--0.97 IPC correlation; PyTorchSim~\cite{pytorchsim2025} integrates PyTorch~2 with NPU simulation.
+Speed ($1000$--$10000\times$ slowdown) makes these impractical for ML design space exploration.
+
+\textbf{Trace-driven simulators} replay execution traces for system-level modeling.
+ASTRA-sim~\cite{astrasim2023} achieves 5--15\% error for distributed training via Chakra traces~\cite{chakra2023}; VIDUR~\cite{vidur2024} provides $<$5\% error for LLM serving; SimAI~\cite{simai2025}, Lumos~\cite{lumos2025}, and Frontier~\cite{frontier2025} target large-scale training and MoE inference.
+Some tools use ML internally (e.g., VIDUR's random forests for kernel prediction), blurring the boundary with hybrid approaches.
+
+\textbf{ML-augmented models} learn performance functions from profiling data: nn-Meter~\cite{nnmeter2021} (random forests for edge devices), LitePred~\cite{litepred2024} (85-platform transfer), HELP~\cite{help2021} (10-sample meta-learning), and TVM~\cite{tvm2018}/Ansor~\cite{ansor2020} (compiler autotuning).
+Their critical failure mode is \emph{silent distribution shift}---CNN-trained models may produce confident but wrong predictions for transformers.
+
+\textbf{Hybrid analytical+ML models} combine physics-based priors with learned residual corrections.
+NeuSight~\cite{neusight2025} achieves 2.3\% MAPE on GPT-3 inference via tile-based prediction; Habitat~\cite{habitat2021} decomposes compute/memory components; ArchGym~\cite{archgym2023} connects ML surrogates to analytical simulators.
+Transfer learning provides 22.5\% average improvement~\cite{latencypredictorsnas2024}.
 
 \subsection{Secondary Axes: Platform and Abstraction Level}
 \label{subsec:by-platform}
@@ -365,9 +438,10 @@ Sparseloop~\cite{sparseloop2022} extends Timeloop to sparse tensors by modeling 
 PyTorchSim~\cite{pytorchsim2025} integrates PyTorch~2 with cycle-accurate NPU simulation, directly consuming computation graphs to eliminate manual workload translation, but does not report real-hardware accuracy and inherits simulation speed limitations.
 ArchGym~\cite{archgym2023} connects ML surrogates to analytical simulators for design space exploration; its 0.61\% RMSE measures surrogate-vs-simulator fidelity, not real-hardware accuracy.
 \textbf{Synthesis.}
-Accelerator modeling is the most mature subdomain, with Timeloop as the de facto DSE standard.
-The key gap is silicon validation---no surveyed accelerator tool validates against manufactured hardware, leaving all anchored to RTL comparisons.
-Emerging PIM modeling tools~\cite{upimulator2024,attacc2024,neupims2024,paise2025} lack real hardware validation (Section~\ref{sec:challenges}).
+Accelerator modeling is the most mature subdomain, with Timeloop achieving a favorable accuracy--speed--interpretability balance as the de facto DSE standard.
+The progression from Timeloop through Sparseloop to PIM-aware tools illustrates a recurring pattern: each extension addresses a new workload characteristic but erodes the simplicity advantage of analytical approaches.
+The key gap is silicon validation---neither ArchGym nor PyTorchSim validates against manufactured hardware, leaving all accelerator tools anchored to RTL comparisons.
+Emerging PIM modeling tools~\cite{upimulator2024,attacc2024,neupims2024,paise2025} target attention acceleration and PIM-GPU co-simulation but lack real PIM hardware validation (Section~\ref{sec:challenges}).
 
 \subsection{GPU Performance Modeling}
 \label{subsec:gpu-modeling}
@@ -389,33 +463,38 @@ Direct comparison requires caution: NeuSight targets 2023--2025 hardware with LL
 
 \textbf{LLM-specific modeling.}
 LLM execution exhibits distinct prefill (compute-bound) and decode (memory-bound) phases~\cite{splitwise2024,distserve2024}.
-VIDUR~\cite{vidur2024} simulates serving with scheduling strategies (Orca~\cite{orca2022}, Sarathi~\cite{sarathi2024}) at $<$5\% error; LIFE~\cite{life2025} and HERMES~\cite{hermes2025} target analytical and disaggregated inference, respectively.
+VIDUR~\cite{vidur2024} simulates LLM serving with scheduling strategies (Orca~\cite{orca2022}, Sarathi~\cite{sarathi2024}) at $<$5\% error.
+LIFE~\cite{life2025} provides hardware-agnostic analytical inference modeling; HERMES~\cite{hermes2025} targets heterogeneous disaggregated serving; and emerging predictors include Omniwise~\cite{omniwise2025} and SwizzlePerf~\cite{swizzleperf2025}.
 
 \textbf{Compiler cost models.}
-TVM~\cite{tvm2018} and Ansor~\cite{ansor2020} use ML cost models for autotuning at $\sim$15\% MAPE; TLP~\cite{tlp2023} uses transformer-based modeling at $<$10\% MAPE.
-SynPerf~\cite{synperf2025} and SwizzlePerf~\cite{swizzleperf2025} prioritize ranking accuracy over absolute error.
+TVM~\cite{tvm2018} and Ansor~\cite{ansor2020} use ML cost models for autotuning at $\sim$15\% MAPE, with TenSet~\cite{tenset2021} enabling pre-training across diverse programs.
+TLP~\cite{tlp2023} uses transformer-based modeling for irregular workloads at $<$10\% MAPE.
+SynPerf~\cite{synperf2025} uses performance models to guide kernel synthesis; both SwizzlePerf~\cite{swizzleperf2025} and SynPerf prioritize ranking accuracy over absolute error.
 
 \textbf{Synthesis.}
-GPU modeling spans the widest methodological range (2\%--24\% error), reflecting the tension between microarchitectural complexity and rapid hardware evolution.
-NeuSight offers the best accuracy--speed trade-off for LLM workloads, while AMALI and LIFE fill the pre-silicon gap despite higher error.
+GPU modeling exhibits the widest methodological spread: cycle-accurate simulation, analytical models, hybrid learned approaches, and compiler cost models all target the same hardware with error rates spanning 2\%--24\%.
+This diversity reflects the fundamental tension between microarchitectural complexity (making analytical modeling hard) and rapid hardware evolution (invalidating training data for learned approaches).
+NeuSight currently offers the best accuracy--speed trade-off for LLM workloads, but per-GPU profiling limits pre-silicon use---a gap that AMALI and LIFE fill despite higher error.
+The compiler cost model ecosystem (TVM, TLP, SynPerf) represents a distinct use case where relative ranking matters more than absolute prediction.
 
 \subsection{Distributed Training and LLM Serving}
 \label{subsec:distributed-modeling}
 
-Distributed systems introduce communication overhead, synchronization barriers, and parallelism strategy choices across tensor~\cite{megatronlm2020}, pipeline~\cite{gpipe2019}, and data parallelism~\cite{zero2020}.
+Distributed systems introduce communication overhead, synchronization barriers, and parallelism strategy choices across tensor~\cite{megatronlm2020}, pipeline~\cite{gpipe2019}, and data parallelism with memory-efficient optimizers~\cite{zero2020}.
 
 \textbf{Training simulation.}
-ASTRA-sim~\cite{astrasim2023} provides end-to-end simulation via Chakra traces~\cite{chakra2023} at 5--15\% error versus HGX-H100 clusters.
-SimAI~\cite{simai2025} achieves 1.9\% MAPE at Alibaba Cloud scale; Lumos~\cite{lumos2025} achieves 3.3\% on H100 training; TrioSim~\cite{triosim2025} and Echo~\cite{echo2024} offer additional approaches.
-PRISM~\cite{prism2025} produces prediction intervals at 10K+ GPU scale.
+ASTRA-sim~\cite{astrasim2023} provides end-to-end training simulation via Chakra traces~\cite{chakra2023} at 5--15\% error versus HGX-H100 clusters.
+SimAI~\cite{simai2025} achieves 1.9\% MAPE at Alibaba Cloud scale; Lumos~\cite{lumos2025} achieves 3.3\% error on H100 training; Echo~\cite{echo2024} and TrioSim~\cite{triosim2025} offer additional training simulation approaches.
+PRISM~\cite{prism2025} produces prediction intervals at 10K+ GPU scale, capturing stochastic variation.
 
 \textbf{Scaling and parallelism.}
 Paleo~\cite{paleo2017} pioneered analytical training-time estimation; MAD Max~\cite{madmax2024} extends this per parallelism dimension; Sailor~\cite{sailor2025} addresses heterogeneous clusters.
 The Llama~3 study~\cite{llama3scaling2025} documents 4D parallelism at 16K H100 GPUs as validation ground truth.
 
 \textbf{Inference serving.}
-VIDUR~\cite{vidur2024} extends to distributed serving with vLLM~\cite{vllm2023} scheduling; Frontier~\cite{frontier2025} targets MoE and disaggregated inference; ThrottLL'eM~\cite{throttllem2025} models GPU power effects.
-KV cache management remains the key bottleneck~\cite{vllm2023}, and algorithmic innovations (speculative decoding~\cite{medusa2024}) create a moving-target challenge for simulators.
+VIDUR~\cite{vidur2024} extends to distributed serving with vLLM~\cite{vllm2023} scheduling; Frontier~\cite{frontier2025} targets MoE and disaggregated inference; ThrottLL'eM~\cite{throttllem2025} models GPU power management effects on inference.
+KV cache management is the key serving bottleneck (vLLM's PagedAttention~\cite{vllm2023} achieves 2--4$\times$ throughput), modeled by VIDUR at the system level.
+Algorithmic innovations like speculative decoding~\cite{medusa2024} create a moving-target challenge for all serving simulators.
 
 \textbf{Synthesis.}
 Distributed modeling is the fastest-growing subdomain, bifurcating into \emph{trace-driven fidelity} (ASTRA-sim, SimAI) and \emph{analytical decomposition} (Paleo, MAD Max), with PRISM's probabilistic approach as an emerging third path.
@@ -425,18 +504,25 @@ Distributed modeling is the fastest-growing subdomain, bifurcating into \emph{tr
 
 Edge devices impose strict power, memory, and latency constraints, and their hardware diversity (mobile CPUs, GPUs, NPUs, DSPs) makes per-device analytical modeling impractical, driving ML-augmented approaches.
 
-nn-Meter~\cite{nnmeter2021} reports $<$1\% MAPE but scores 3/10 in our reproducibility evaluation (Section~\ref{sec:evaluation}) due to unpinned dependencies.
-LitePred~\cite{litepred2024} achieves 0.7\% MAPE across 85 (predominantly ARM) platforms; HELP~\cite{help2021} achieves 1.9\% via 10-sample meta-learning adaptation.
-ESM~\cite{esm2025} finds well-tuned random forests match deep learning surrogates, and transfer learning provides 22.5\% average improvement~\cite{latencypredictorsnas2024}.
+nn-Meter~\cite{nnmeter2021} reports $<$1\% MAPE using random forest ensembles, but this claim is unverifiable: pre-trained predictors fail with modern scikit-learn versions, scoring 3/10 in our reproducibility evaluation (Section~\ref{sec:evaluation}).
+LitePred~\cite{litepred2024} achieves 0.7\% MAPE across 85 platforms using VAE-based intelligent sampling that reduces adaptation to under one hour per device, though the platforms are predominantly ARM-based and transfer to NPUs/DSPs likely degrades.
+HELP~\cite{help2021} achieves 1.9\% MAPE with MAML-style 10-sample adaptation, though accuracy depends on selecting representative operators for the target workload.
+ESM~\cite{esm2025} systematically evaluates surrogate models for hardware-aware NAS, finding that well-tuned random forests match deep learning surrogates---suggesting the field may over-invest in model complexity relative to data quality.
+Transfer learning provides 22.5\% average improvement, up to 87.6\% on challenging cross-platform transfers~\cite{latencypredictorsnas2024}.
 
 \textbf{Synthesis.}
-Edge modeling is dominated by ML-augmented approaches with data quality and tool longevity mattering more than model sophistication---nn-Meter's reproducibility failure (Section~\ref{sec:evaluation}) underscores this lesson.
+Edge modeling is dominated by ML-augmented approaches, with the central challenge being \emph{generalization} to new devices with minimal profiling.
+ESM's finding that simple models match complex ones, combined with nn-Meter's reproducibility failure, suggests that data quality and tool longevity matter more than model sophistication.
 
 \subsection{Cross-Cutting Themes}
 \label{subsec:cross-cutting}
 
-\emph{Structural decomposition} mirroring hardware execution outperforms black-box approaches (Timeloop's loop nests, NeuSight's tiles, VIDUR's prefill/decode), while \emph{verifiable moderate accuracy} matters more than unverifiable high accuracy (Docker-first tools: 8.5+/10 vs.\ nn-Meter: 3/10).
-A persistent \textbf{accuracy--generality--speed trilemma} explains why no single methodology dominates: each maximizes a different vertex at the expense of the others.
+Several themes cut across platform categories.
+\emph{Structural decomposition} mirroring hardware execution outperforms black-box approaches: Timeloop's loop nests, NeuSight's tiles, and VIDUR's prefill/decode separation all achieve strong accuracy by encoding domain knowledge into the model structure, while modular pluggable backends (ASTRA-sim, VIDUR) enable broad adoption.
+\emph{Verifiable moderate accuracy} matters more than \emph{unverifiable high accuracy}---Timeloop (9/10 reproducibility) and ASTRA-sim (8.5/10) see sustained adoption, while nn-Meter ($<$1\% MAPE claimed, 3/10 reproducibility) sees decline.
+
+A persistent \textbf{accuracy--generality--speed trilemma} explains why no single methodology has displaced others: cycle-accurate simulators maximize accuracy but sacrifice speed; analytical models maximize speed but sacrifice accuracy on complex hardware; ML-augmented approaches achieve both but sacrifice generality, requiring retraining when hardware changes.
+The maturity of each subdomain mirrors economic incentive: accelerator DSE is most mature (irreversible chip design errors), distributed training simulation is fastest-growing (million-dollar training runs), and edge modeling has weakest reproducibility (lower deployment costs).
 
 % ==============================================================================
 % COMPARISON AND ANALYSIS
@@ -514,11 +600,12 @@ Setup costs vary dramatically: analytical models require only architecture speci
 \subsection{Practitioner Tool Selection}
 \label{subsec:tool-selection}
 
-Tool selection follows platform and use case.
-For \emph{accelerator DSE}, use Timeloop or MAESTRO for microsecond-speed exhaustive search with interpretable bottleneck feedback.
-For \emph{GPU evaluation}, NeuSight offers the best accuracy--speed balance for LLMs; use Accel-Sim when microarchitectural detail is needed.
-For \emph{distributed systems}, use VIDUR for LLM serving configuration and ASTRA-sim or SimAI for training parallelism at scale.
+Tool selection depends on the target platform, acceptable error margin, and available setup time.
+For \emph{accelerator DSE}, use Timeloop or MAESTRO for microsecond-speed exhaustive search with interpretable bottleneck feedback; Sparseloop extends this to sparse workloads.
+For \emph{GPU evaluation}, NeuSight offers the best accuracy--speed balance for LLMs; use Accel-Sim when microarchitectural detail is needed, accepting the $1000\times$ slowdown.
+For \emph{distributed systems}, use VIDUR for LLM serving configuration and ASTRA-sim or SimAI for training parallelism at scale; MAD Max provides fast analytical estimates when trace collection is impractical.
 For \emph{edge devices}, LitePred offers the broadest platform coverage, while HELP excels with minimal profiling data.
+Practitioners should prioritize tools with Docker-first deployment (VIDUR, Timeloop, ASTRA-sim) over tools with unpinned dependencies, as our evaluation shows reproducibility scores strongly predict long-term usability.
 
 % ==============================================================================
 % EXPERIMENTAL EVALUATION


### PR DESCRIPTION
## Summary
- Restored timeline figure in Introduction showing tool evolution (2016-2026) — adds 4th figure
- Expanded Section 4.1 methodology descriptions with per-type detail (analytical, cycle-accurate, trace-driven, ML-augmented, hybrid)
- Expanded Section 5 tool descriptions: GPU synthesis, distributed systems, edge modeling, accelerator synthesis, compiler cost models
- Expanded Section 6 tool selection guidance with practical deployment advice
- Expanded cross-cutting themes with maturity-incentive observation

## Verification
- Compiled locally with Docker (texlive/texlive:latest): **11 pages** (within 10.5-11 target)
- 77 cited references (>75 requirement)
- 4 figures (>3 requirement)
- 0 LaTeX warnings or errors
- All cross-references intact

## Test plan
- [ ] CI build confirms page count 10.5-11
- [ ] All three contributions clearly present
- [ ] No broken cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)