### PR TITLE
[Paper-Editor] Fix abstract/evaluation contradiction

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -62,7 +62,7 @@
 As machine learning workloads grow in scale and complexity, architects need fast, accurate methods to predict performance across diverse hardware.
 This survey analyzes 22 tools from 53 papers across architecture and systems venues (2016--2026), covering analytical models, trace-driven simulators, and ML-augmented hybrid techniques for DNN accelerators, GPUs, distributed training, and LLM inference serving.
 We organize the literature by methodology type, target platform, and abstraction level, identifying a temporal validation lag where tools published before 2023 validated primarily on CNNs and finding that hybrid approaches achieve the best accuracy-speed trade-offs.
-We conduct hands-on evaluations of representative tools, independently measuring their performance and accuracy rather than relying on original claims; tools with Docker-first deployment remain reproducible, while those relying on serialized ML models become unusable.
+We conduct hands-on reproducibility evaluations of representative tools, assessing whether practitioners can reproduce each tool's functionality without the original authors' environment; tools with Docker-first deployment remain reproducible, while those relying on serialized ML models become unusable.
 We identify open challenges including cross-workload generalization, kernel-to-end-to-end error composition, and emerging architecture support, providing practitioners tool selection guidance and researchers a roadmap for the field.
 \end{abstract}
 


### PR DESCRIPTION
## Summary
- Fixes P0 contradiction from issue #89: abstract claimed "independently measuring their performance and accuracy" while Section 7 says "we do not validate accuracy claims"
- Reframed abstract line to say "hands-on reproducibility evaluations...assessing whether practitioners can reproduce each tool's functionality" — consistent with Section 7's actual scope
- LaTeX compiles cleanly: 12 pages, 0 errors, 0 undefined references

## Test plan
- [x] Verify abstract no longer mentions accuracy evaluation
- [x] Verify consistency with Section 7 evaluation scope
- [x] LaTeX compilation succeeds with no errors
- [x] Page count unchanged (12 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)