### PR TITLE
[Paper-Editor] Fix Figure 5 stale Pareto frontier reference (#92)

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -630,13 +630,11 @@ Figure~\ref{fig:accuracy-speed} visualizes the accuracy--speed trade-off space, 
 \node[font=\tiny, anchor=south east] at (0.9,0.7) {LitePred};
 \node[font=\tiny, anchor=north west] at (1.1,1.9) {HELP};
 \node[font=\tiny, anchor=south west] at (1.1,15) {TVM};
-% Pareto frontier (dashed)
-\draw[thick, dashed, black!40] (0,7.5) -- (1,2.3) -- (2,5) -- (3,1.9);
 \legend{Analytical, Simulation, Hybrid, Trace-driven, ML-augmented}
 \end{axis}
 \end{tikzpicture}%
 }
-\caption{Accuracy--speed trade-off across surveyed tools. Each point represents a tool's reported MAPE vs.\ evaluation speed (log-scale categories). The dashed line traces the approximate Pareto frontier. Hybrid (NeuSight) and trace-driven (SimAI) approaches dominate the frontier.}
+\caption{Accuracy--speed trade-off across surveyed tools. Each point represents a tool's reported MAPE vs.\ evaluation speed (log-scale categories). Hybrid (NeuSight) and trace-driven (SimAI) approaches achieve the best accuracy--speed balance.}
 \label{fig:accuracy-speed}
 \end{figure}
 


### PR DESCRIPTION
## Summary
- Removed the dashed Pareto frontier line from Figure 5 that was not a valid Pareto frontier (MAPE increases from NeuSight 2.3% to VIDUR 5%, violating Pareto optimality)
- Updated caption to remove stale "dashed line traces the approximate Pareto frontier" text
- Replaced with cleaner statement: "Hybrid (NeuSight) and trace-driven (SimAI) approaches achieve the best accuracy--speed balance"

## Test plan
- [ ] Verify LaTeX compiles without errors
- [ ] Verify Figure 5 renders correctly without the dashed line
- [ ] Verify caption text is accurate and complete

Fixes issue #92 (M2 from paragraph review #86)

🤖 Generated with [Claude Code](https://claude.com/claude-code)