### PR TITLE
Fix VIDUR table data to match CI experiments

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -818,26 +818,26 @@ nn-Meter & 2 & 0 & 1 & 3/10 \\
 \label{subsec:per-tool-results}
 
 \textbf{VIDUR} (9/10).
-We simulated Llama-2-7B on a simulated A100 under two scheduler configurations (Table~\ref{tab:vidur-results}).
-Note that the two schedulers were run at different arrival rates (QPS 2.0 vs.\ 4.0), so their latency metrics are \emph{not directly comparable}; rather, the results illustrate VIDUR's ability to model distinct scheduling behaviors.
-The vLLM scheduler preempted 28\% of requests even at lower load, while Sarathi's chunked prefill~\cite{sarathi2024} avoided preemptions entirely despite 2$\times$ higher arrival rate---consistent with the KV-cache management differences described in the respective papers~\cite{vllm2023,sarathi2024}.
+We simulated Llama-2-7B on a simulated A100 under two scheduler configurations at QPS~2.0 (Table~\ref{tab:vidur-results}).
+The Sarathi scheduler with chunked prefill~\cite{sarathi2024} achieves lower end-to-end latency than vLLM (avg 0.158\,s vs.\ 0.177\,s; P99 0.262\,s vs.\ 0.314\,s), consistent with Sarathi's more efficient prefill--decode interleaving.
+Neither scheduler triggered preemptions at this load level, confirming that the simulated A100 KV-cache capacity is sufficient for both configurations~\cite{vllm2023,sarathi2024}.
 
 \begin{table}[t]
 \centering
-\caption{VIDUR simulation results for Llama-2-7B inference serving on a simulated A100 GPU (100 requests each, seed=42). Schedulers use different arrival rates, so latency values are not directly comparable; results illustrate VIDUR's scheduling model fidelity. All metrics from our own experiments.}
+\caption{VIDUR simulation results for Llama-2-7B inference serving on a simulated A100 GPU (Poisson arrivals at QPS~2.0, seed=42). All metrics from our own experiments.}
 \label{tab:vidur-results}
 \small
 \begin{tabular}{lcc}
 \toprule
 \textbf{Metric} & \textbf{vLLM} & \textbf{Sarathi} \\
 \midrule
-Requests & 100 & 100 \\
-QPS (Poisson) & 2.0 & 4.0 \\
-Avg E2E latency (s) & 0.170 & 0.174 \\
-P99 E2E latency (s) & 0.285 & 0.294 \\
-Avg TTFT (s) & 0.027 & 0.028 \\
-Avg TPOT (s) & 0.0093 & 0.0095 \\
-Requests preempted & 28 & 0 \\
+Requests & 200 & 50 \\
+QPS (Poisson) & 2.0 & 2.0 \\
+Avg E2E latency (s) & 0.177 & 0.158 \\
+P99 E2E latency (s) & 0.314 & 0.262 \\
+Avg TTFT (s) & 0.027 & 0.025 \\
+Avg TPOT (s) & 0.0093 & 0.0090 \\
+Requests preempted & 0 & 0 \\
 \bottomrule
 \end{tabular}
 \end{table}


### PR DESCRIPTION
## Summary
- Updated `tab:vidur-results` to match committed CI experiment CSV data
- vLLM: 200 requests at QPS 2.0 (was incorrectly listed as 100 requests)
- Sarathi: 50 requests at QPS 2.0 (was incorrectly listed as 100 requests at QPS 4.0)
- Corrected all latency metrics from raw CSV data (vLLM avg E2E 0.177s, Sarathi 0.158s)
- Fixed preemption count: 0 for both schedulers (was incorrectly 28 for vLLM)
- Rewrote prose paragraph since both schedulers use the same QPS and results are directly comparable

## Test plan
- [ ] Verify LaTeX compiles without errors (CI)
- [ ] Verify table values match CSV files in `data/results/vidur/flux_run/`
- [ ] Verify prose accurately describes the corrected experimental results

Fixes issue #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)