### PR TITLE
[Paper-Editor] Fix NeuSight composite score arithmetic error (#242)

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -660,7 +660,7 @@ Table~\ref{tab:mtap-results} summarizes the multi-dimensional assessment.
 VIDUR & M ($<$5\%) & H & L & H & M & 2.1 \\
 Timeloop & M (5--10\%) & M & M & M & H & 2.1 \\
 ASTRA-sim & M (5--15\%) & M & M & H & H & 2.2 \\
-NeuSight & M (2.3\%) & M & L & L & L & 1.5 \\
+NeuSight & M (2.3\%) & M & L & L & L & 1.6 \\
 nn-Meter & F ($<$1\%$^\dagger$) & F & F & F & F & 0.0 \\
 \bottomrule
 \end{tabular}
@@ -946,7 +946,7 @@ The tool ultimately runs after manual setup, but the process is undocumented and
 Adding new GPU architectures requires retraining the tile prediction model with profiling data from the target GPU---a process that requires hardware access and is not documented beyond the original experimental setup.
 New operator types require extending the tile decomposition logic in source code.
 
-\emph{Composite score:} $S(\text{NeuSight}) = 0.4 \times 2 + 0.2 \times 2 + 0.2 \times 1 + 0.1 \times 1 + 0.1 \times 1 = 1.5$ (Table~\ref{tab:mtap-results}), with strength in prediction accuracy offset by deployment and extensibility limitations.
+\emph{Composite score:} $S(\text{NeuSight}) = 0.4 \times 2 + 0.2 \times 2 + 0.2 \times 1 + 0.1 \times 1 + 0.1 \times 1 = 1.6$ (Table~\ref{tab:mtap-results}), with strength in prediction accuracy offset by deployment and extensibility limitations.
 
 \textbf{nn-Meter.}
 After four attempts ($>$4h), no predictions ran: pickle-serialized predictors (scikit-learn 0.23.1) are incompatible with current scikit-learn versions---a concrete demonstration of temporal instability (D3).
@@ -984,7 +984,7 @@ This principle explains why AMALI's memory hierarchy model (23.6\% MAPE) underpe
 
 \emph{Fourth}, \textbf{self-reported accuracy and practical tool quality are weakly correlated.}
 Ranking the five tools by self-reported MAPE yields: nn-Meter ($<$1\%) $>$ NeuSight (2.3\%) $>$ VIDUR ($<$5\%) $>$ Timeloop (5--10\%) $>$ ASTRA-sim (5--15\%).
-Ranking by composite MTAP score yields the inverse order for the extremes: ASTRA-sim (2.2) $>$ VIDUR (2.1) = Timeloop (2.1) $>$ NeuSight (1.5) $>$ nn-Meter (0.0).
+Ranking by composite MTAP score yields the inverse order for the extremes: ASTRA-sim (2.2) $>$ VIDUR (2.1) = Timeloop (2.1) $>$ NeuSight (1.6) $>$ nn-Meter (0.0).
 The Spearman rank correlation between self-reported accuracy and MTAP score is $\rho_s = -0.9$ ($p < 0.05$, $N=5$), indicating a strong negative relationship.
 While the sample size is small, this finding challenges the field's implicit assumption that lower reported error implies a better tool, and motivates multi-dimensional evaluation as standard practice.
 

--- a/reports/mtap-critical-assessment-v3.md
+++ b/reports/mtap-critical-assessment-v3.md
@@ -99,7 +99,7 @@ The paper now makes a credible case that MTAP is a novel evaluation framework co
 
 **P1.1: VIDUR D2 scoring inconsistency.** VIDUR receives H (3) on D2 but does not perform multi-level composition. Per the paper's own rubric (Table `scoring-rubrics`), H requires "Validated multi-level composition with γ < 0.10." VIDUR profiles at the phase level, which §7.2 describes as "sidestepping composition." This should be M (2) at most ("Single-level prediction with documented scope"), or a new rubric row should be added for "validated single-level prediction that avoids composition entirely." This inconsistency would be caught by any attentive reviewer.
 
-**Impact:** If VIDUR D2 drops from H (3) to M (2), S(VIDUR) = 0.4×2 + 0.2×2 + 0.2×1 + 0.1×3 + 0.1×2 = 1.9 (down from 2.1). This changes the tool ranking: ASTRA-sim (2.2) > Timeloop (2.1) > VIDUR (1.9) > NeuSight (1.5). The sensitivity analysis must be re-run.
+**Impact:** If VIDUR D2 drops from H (3) to M (2), S(VIDUR) = 0.4×2 + 0.2×2 + 0.2×1 + 0.1×3 + 0.1×2 = 1.9 (down from 2.1). This changes the tool ranking: ASTRA-sim (2.2) > Timeloop (2.1) > VIDUR (1.9) > NeuSight (1.6). The sensitivity analysis must be re-run.
 
 **P1.2: D1 rubric OR/AND ambiguity.** The M (2) row uses OR in a way that conflates two different situations. Suggest restructuring as:
 - M (2): "MAPE < 15% with independent verification, OR self-reported MAPE < 5% without independent verification (capped at M)"


### PR DESCRIPTION
## Summary
- Fixed NeuSight composite MTAP score from 1.5 to 1.6 (correct arithmetic: 0.4×2 + 0.2×2 + 0.2×1 + 0.1×1 + 0.1×1 = 1.6)
- Updated 3 locations in `paper/main.tex`: MTAP results table (line 663), NeuSight scorecard composite score (line 949), cross-cutting findings ranking (line 987)
- Updated 1 location in `reports/mtap-critical-assessment-v3.md`: sensitivity analysis ranking
- Verified all other tool composite scores (VIDUR 2.1, Timeloop 2.1, ASTRA-sim 2.2) are arithmetically correct
- Verified uniform-weight NeuSight score (1.4) is correct and unchanged

## Test plan
- [ ] CI build-pdf confirms LaTeX compiles successfully
- [ ] Manual verification: 0.4×2 + 0.2×2 + 0.2×1 + 0.1×1 + 0.1×1 = 0.8 + 0.4 + 0.2 + 0.1 + 0.1 = 1.6

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)