### PR TITLE
Critical assessment v4: post-restructure evaluation review

### DIFF
--- a/reports/critical-assessment-v4-post-restructure.md
+++ b/reports/critical-assessment-v4-post-restructure.md
@@ -1,0 +1,233 @@
+# Critical Assessment v4: Post-MTAP Restructure Review
+
+**Reviewer:** Critical Red Team Reviewer
+**Date:** 2026-02-16
+**Paper:** "A Survey of High-Level Modeling and Simulation Methods for Modern Machine Learning Workloads"
+**Venue:** MICRO 2026
+**Paper state:** Post-restructure (MTAP replaced with accuracy-centered evaluation)
+
+---
+
+## Overall Score: Weak Accept (4.3/6)
+
+Up from 4.2/6 in v3. The MTAP replacement is a net positive—the paper now makes honest, defensible claims instead of overclaiming a formal framework with undefined components. However, the evaluation falls well short of the 50% content target and the paper has new structural problems.
+
+---
+
+## 1. What Improved (MTAP → Accuracy-Centered)
+
+### 1.1 Honesty of Claims
+The paper no longer claims a "novel evaluation framework" with formal scoring functions it never defines. The new framing—"accuracy-centered independent evaluation"—accurately describes what the paper actually does: run tools, compare outputs to claims, document failures. This is refreshingly honest and eliminates the overclaiming vulnerability.
+
+### 1.2 Contribution Framing
+The four contributions (line 94-100) are well-defined and defensible:
+1. Accuracy-centered independent evaluation (real experiments)
+2. Feature availability matrix (genuinely useful)
+3. Unified simulation pipeline proposal (solid vision)
+4. Coverage matrix + research agenda
+
+### 1.3 Cross-Cutting Findings (Section 6.6)
+The three findings—self-reported accuracy inversely correlated with reliability, tools are complementary not competing, composition gap dominates—are genuinely insightful and well-supported by data. This is the strongest part of the paper.
+
+### 1.4 Threats to Validity (Section 6.7)
+Honest acknowledgment of limitations (no GPU, N=5, NeuSight uses own labels). This is mature scientific writing.
+
+---
+
+## 2. Critical Problems
+
+### P1. Evaluation Content Falls Far Short of 50% Target (CRITICAL)
+
+**The roadmap explicitly requires "at least 50% of paper weight on third-party evaluation with novel methodology."** Current state:
+
+| Section | Lines | % of Paper |
+|---------|-------|-----------|
+| Evaluation Methodology (§5) | 41 | 4.7% |
+| Evaluation Results (§6) | 228 | 26.2% |
+| **Total Evaluation** | **269** | **30.9%** |
+
+This is 30.9%—significantly below the 50% target. The gap is ~166 lines (19.1 percentage points).
+
+**Impact:** The paper still reads as "survey with evaluation section" rather than "evaluation-first paper with survey context" as the roadmap demands. A MICRO reviewer would note the evaluation is substantial but not the centerpiece.
+
+### P2. No "Novel Methodology" Contribution Remains
+
+The MTAP framework, despite its flaws, was positioned as a novel contribution. The replacement—running tools and reporting results—is **good practice** but not itself a novel methodology. The paper's contribution list (line 96) says "accuracy-centered independent evaluation" but this is just... doing experiments properly.
+
+**What's missing:** A principled, reproducible evaluation *protocol* that the community could adopt. The paper describes what it did but doesn't formalize it into a reusable methodology. Consider:
+- Formal definition of what "independent evaluation" means (criteria for claim verification)
+- A reproducibility scorecard (dependency age, containerization, documentation quality)
+- A trust-level taxonomy for accuracy claims (independently verified → hardware-verified → self-reported → unverifiable)
+
+Without this, the paper has three contributions (evaluation data, feature matrix, pipeline vision) but not the "novel evaluation methodology" the roadmap requires.
+
+### P3. NeuSight Analysis Methodology Weakness
+
+The paper's strongest evaluation result—NeuSight's accuracy overstated 2-4x—has an important methodological caveat that undermines it: the analysis uses **NeuSight's own prediction/label pairs** (line 466), not independent hardware measurements.
+
+This means:
+- The labels could themselves be inaccurate (profiler noise, measurement setup differences)
+- The "verification" is really a re-analysis of the tool's own training/test data
+- A skeptical reviewer could argue this is verification of the tool's self-consistency, not its accuracy
+
+**Fix:** Explicitly frame this as "re-analysis under different aggregation methodology" rather than "independent verification." The finding is still valuable (it shows the published headline number cherry-picks the best GPU), but the framing should be precise.
+
+### P4. ASTRA-sim and VIDUR: Internal Consistency ≠ Accuracy Verification
+
+For both ASTRA-sim (§6.2) and VIDUR (§6.3), the paper repeatedly acknowledges that absolute accuracy is unverifiable. The findings reduce to:
+- ASTRA-sim: "collectives scale as expected" (not surprising)
+- VIDUR: "Sarathi beats vLLM" (already known from the Sarathi paper)
+
+**The paper evaluates 5 tools but only has a genuine accuracy finding for 2 (NeuSight and nn-Meter).** For the other 3, it confirms internal plausibility—necessary but not sufficient for a venue like MICRO.
+
+### P5. Composition Gap Claim Needs Stronger Evidence
+
+The composition gap (kernel 5-9% → model 10-28%) is the paper's most important finding. But:
+- The evidence comes entirely from NeuSight's data (one tool)
+- The error growth formula (σ_model ≈ σ_kernel · √N) is presented without derivation or validation
+- No attempt to empirically measure the composition gap directly (e.g., sum individual kernel predictions vs. measured end-to-end)
+- The claim that composition error > kernel error is stated but not rigorously demonstrated
+
+**Fix:** Either (a) demonstrate the gap empirically for at least one model (sum NeuSight kernel predictions vs. model-level prediction vs. ground truth) or (b) frame it more carefully as "observed growth pattern consistent with composition effects" rather than a definitive measurement.
+
+---
+
+## 3. Structural Issues
+
+### S1. Section Balance Remains Skewed
+
+| Content Category | Lines | % | Target |
+|-----------------|-------|---|--------|
+| Introduction + Methodology | 91 | 10.5% | ~10% |
+| Background + Taxonomy | 177 | 20.4% | ~15% |
+| Survey of Approaches | 86 | 9.9% | ~10% |
+| **Evaluation (§5+§6)** | **269** | **30.9%** | **~50%** |
+| Pipeline + Challenges | 150 | 17.3% | ~15% |
+| Conclusion | 18 | 2.1% | ~2% |
+
+The taxonomy (20.4%) and survey (9.9%) together take 30.3%—nearly as much as evaluation. The roadmap says to compress survey/taxonomy to ~25%.
+
+**Recommendation:** Move ~50-70 lines from taxonomy/survey into evaluation depth. Specifically:
+- §4.1 (Methodology-Platform Pairings, lines 288-292) largely repeats Table 1—compress to 2 sentences
+- §4.2 (Workload Coverage, lines 337-341) could be a brief note after Table 1
+- §5.3 (Survey sub-sections) could be compressed by removing redundancy with Table 2
+
+### S2. Pipeline Section (§7) is Thin
+
+The "Toward a Unified Simulation Pipeline" (32 lines, 3.7%) is one of the four claimed contributions but receives minimal space. For something called a "contribution," it should be either:
+- Expanded with more technical depth (formal interface definitions, error propagation analysis), or
+- Downgraded from a "contribution" to a "discussion" and folded into the challenges section
+
+### S3. Two Trace-Driven Tools, Zero Analytical Experiments with Verification
+
+The paper selects one tool per methodology type but evaluates two trace-driven tools (ASTRA-sim, VIDUR). Meanwhile, Timeloop's evaluation (§6.4) is 6 lines of bullet points with no table. The evaluation depth is imbalanced.
+
+---
+
+## 4. What a MICRO Reviewer Would Say
+
+### Strengths
+- The three cross-cutting findings (§6.6) are genuinely valuable and would be novel to most readers
+- The feature availability matrix (Table 5) is the most useful table in the paper
+- Honest about limitations (§6.7)—refreshing compared to papers that claim comprehensive evaluation with N=1
+- The nn-Meter failure case is an important cautionary tale for the community
+- Good framing of composition gap as the critical unsolved problem
+
+### Weaknesses
+- Evaluation is still too thin for MICRO: 5 tools, no GPU hardware, 3/5 tools only verified for internal consistency
+- No novel methodology contribution: running tools and reporting results is expected of any evaluation, not a contribution itself
+- The composition gap finding is the paper's most important claim but is supported by indirect evidence from a single tool
+- The unified pipeline is a vision without implementation or formal specification
+- Survey sections (taxonomy + tool summaries) consume too much space relative to novel evaluation content
+
+### Questions to Authors
+1. "You evaluate NeuSight using its own data. How do you know the ground-truth labels are accurate?"
+2. "The composition gap is your key finding. Can you demonstrate it empirically for even one model?"
+3. "What specifically is the 'novel evaluation methodology'? How does it differ from standard practice of running tools and reporting accuracy?"
+4. "With N=5 and no GPU, what confidence should readers place in the generalizability of your findings?"
+
+---
+
+## 5. Recommendations (Priority Order)
+
+### Priority 1: Establish Novel Methodology Contribution
+
+**Define a formal, reusable evaluation protocol** that goes beyond "we ran the tools." Propose:
+
+1. **Trust-level taxonomy for accuracy claims:**
+   - Level 4: Independently verified on hardware by third party
+   - Level 3: Verified against hardware by original authors with documented setup
+   - Level 2: Self-reported on authors' benchmarks
+   - Level 1: Claimed without sufficient detail to reproduce
+   - Level 0: Unverifiable (broken artifacts)
+
+   Apply this taxonomy to all 22 tools, not just the 5 you evaluated.
+
+2. **Reproducibility scorecard** (formalizes what you learned from nn-Meter):
+   - Artifact availability (source, data, dependencies)
+   - Containerization (Docker/Singularity)
+   - Dependency freshness (years since last update)
+   - Documentation quality (setup guide, expected outputs)
+
+   This is a genuine contribution the community would use.
+
+3. **Accuracy verification protocol:**
+   - Define what constitutes "independent verification" vs. "re-analysis"
+   - Specify minimum requirements (hardware match, workload match, metric match)
+   - Distinguish absolute verification from relative validation
+
+This framework—trust taxonomy + reproducibility scorecard + verification protocol—is a genuine methodological contribution. It's what MTAP tried to be but done honestly.
+
+### Priority 2: Expand Evaluation to Hit 50% Target
+
+To reach ~435 lines (50%):
+- Add the trust-level taxonomy applied to all 22 tools (~40 lines + table)
+- Add the reproducibility scorecard for all 22 tools (~30 lines + table)
+- Expand NeuSight analysis with per-model breakdown across GPUs (~30 lines + table/figure)
+- Add NeuSight composition gap empirical demonstration: sum kernel predictions vs. model prediction for 1-2 models (~40 lines)
+- Expand Timeloop evaluation with a second architecture or workload (~20 lines)
+- Total new evaluation content: ~160 lines → reaching ~430 lines (49.5%)
+
+Simultaneously compress taxonomy (§4) by ~30 lines and survey (§5) by ~20 lines.
+
+### Priority 3: Strengthen Composition Gap Evidence
+
+This is the paper's strongest potential finding. Currently it's stated but not proven. Options:
+1. **Best:** Re-run NeuSight to get kernel-level predictions for one model, sum them, compare to model-level prediction and ground truth
+2. **Acceptable:** Analyze NeuSight's existing per-kernel and per-model data to compute the gap directly
+3. **Minimum:** Clearly state this is an observed pattern from one tool's data, not a general finding
+
+### Priority 4: Decide Pipeline's Status
+
+Either:
+- **Expand:** Add formal interface specification, error propagation analysis, and at least a proof-of-concept pipeline for one workload
+- **Downgrade:** Move to §8 as a "future directions" discussion, remove from contribution list, and replace with the evaluation methodology framework as contribution #3
+
+---
+
+## 6. Score Trajectory
+
+| Version | Score | Key Change |
+|---------|-------|------------|
+| v1 (initial MTAP) | 3.5/6 (Weak Reject) | Overclaimed framework, no rubrics, γ unmeasured |
+| v2 (enhanced MTAP) | 3.9/6 (Weak Accept-) | Better structure, but rubrics still missing |
+| v3 (expanded MTAP) | 4.2/6 (Weak Accept) | Rubrics added, D2 scoring bug found |
+| **v4 (post-restructure)** | **4.3/6 (Weak Accept)** | Honest claims, but missing methodology contribution |
+
+### Path to Accept (5.0/6):
+1. Define formal evaluation protocol (trust taxonomy + reproducibility scorecard) → +0.3
+2. Expand evaluation to ~50% of paper → +0.2
+3. Empirically demonstrate composition gap → +0.2
+4. Resolve pipeline contribution status → +0.1
+
+All four are achievable within the current paper structure. The paper is genuinely close.
+
+---
+
+## 7. Bottom Line
+
+**The MTAP replacement was the right call.** The paper now makes honest, defensible claims rather than overclaiming a formal framework with undefined components. The three cross-cutting findings are strong.
+
+**But the paper has a contribution gap.** Removing MTAP eliminated the "novel evaluation methodology" contribution without replacing it. The paper needs to formalize its evaluation approach into a reusable protocol (trust taxonomy + reproducibility scorecard) to fill this gap. Without it, the paper is a competent survey with some experiments—valuable, but below the MICRO bar for novelty.
+
+**The 50% target is not met.** Evaluation content is 30.9% vs. the 50% target. This is the single largest gap between the paper's actual state and the stated goals. Closing it requires both expanding evaluation content (~160 lines of new material) and compressing non-evaluation sections (~50 lines of cuts).


### PR DESCRIPTION
## Summary
- Full critical review of paper after MTAP was replaced with accuracy-centered evaluation (PR #270)
- Score: Weak Accept (4.3/6), up from 4.2/6 in v3
- MTAP replacement was correct—honest, defensible claims now
- Key finding: evaluation is 30.9% of paper, well below the 50% target
- Paper has a contribution gap: no "novel methodology" after MTAP removal
- Proposes trust-level taxonomy + reproducibility scorecard as replacement methodology contribution
- Path to Accept (5.0/6) identified with 4 actionable items

## Report
Full report at `reports/critical-assessment-v4-post-restructure.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)