### PR TITLE
Third compression pass: text + TikZ figure compaction

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -72,10 +72,10 @@ Third, the kernel-to-model composition gap (2--9\% kernel error growing to 10--2
 Domain-specific architectures~\cite{hennessy2019golden,tpuv1_2017,tpuv4_2023} make performance prediction critical for ML workload deployment, yet no prior work examines \emph{why} certain approaches succeed---analytical models~\cite{timeloop2019,maestro2019}, trace-driven simulators~\cite{astrasim2023,vidur2024}, hybrid approaches~\cite{neusight2025}---or how errors propagate across the abstraction stack; existing surveys focus on ML \emph{techniques} for modeling~\cite{granite2022} or specific hardware~\cite{timeloop2019}.
 We contribute an \textbf{accuracy-centered independent verification framework} paired with an \textbf{LLM-focused benchmark suite}, replacing self-reported accuracy with reproducible evaluation revealing claimed error rates are overstated by $2$--$4\times$:
 \begin{itemize}
-    \item A \textbf{28-scenario LLM benchmark suite} spanning training and inference, revealing 50\% of scenarios have zero tool support (Section~\ref{sec:eval-framework}).
-    \item \textbf{Independent accuracy verification} of five tools (146 GPU configurations, collective benchmarks, LLM serving simulations, energy validation), showing self-reported claims are systematically overstated (Section~\ref{sec:eval-results}).
-    \item A \textbf{unified simulation pipeline} across five layers, identifying the kernel-to-model composition gap as the critical missing piece (Section~\ref{sec:unified-pipeline}).
-    \item A \textbf{coverage matrix} with a \textbf{research agenda} for composition modeling, unified formats, cross-hardware transfer, and continuous validation (Sections~\ref{sec:taxonomy},~\ref{sec:challenges}).
+\item A \textbf{28-scenario LLM benchmark suite} spanning training and inference, revealing 50\% of scenarios have zero tool support (Section~\ref{sec:eval-framework}).
+\item \textbf{Independent accuracy verification} of five tools (146 GPU configs, collectives, LLM serving, energy), showing self-reported claims are systematically overstated (Section~\ref{sec:eval-results}).
+\item A \textbf{unified simulation pipeline} across five layers, identifying the kernel-to-model composition gap as the critical missing piece (Section~\ref{sec:unified-pipeline}).
+\item A \textbf{coverage matrix} and \textbf{research agenda} for composition modeling, unified formats, cross-hardware transfer, and continuous validation (Sections~\ref{sec:taxonomy},~\ref{sec:challenges}).
 \end{itemize}
 
 \begin{figure}[t]
@@ -87,7 +87,7 @@ We contribute an \textbf{accuracy-centered independent verification framework} p
 \node[eventnode, above] at (0.3,0.3) {Eyeriss\\Paleo}; \node[eventnode, below] at (1.2,-0.3) {TVM}; \node[eventnode, above] at (2.2,0.3) {Timeloop\\MAESTRO}; \node[eventnode, below] at (3,-0.3) {Ansor\\ASTRA-sim};
 \node[eventnode, above] at (3.8,0.3) {nn-Meter\\Habitat}; \node[eventnode, below] at (4.5,-0.3) {Sparseloop\\Accel-Sim}; \node[eventnode, above] at (5.3,0.3) {TLP\\ASTRA-sim 2.0}; \node[eventnode, below] at (6,-0.3) {VIDUR\\Splitwise};
 \node[eventnode, above] at (7.2,0.3) {NeuSight\\AMALI}; \node[eventnode, below] at (8.5,-0.3) {Frontier\\Lumos};
-\draw[thick, ->, blue!50, dashed] (0.5,1.2) -- (8.2,1.2); \node[font=\tiny, text=blue!60, above] at (4.3,1.2) {Toward hybrid analytical+learned models};
+\draw[thick, ->, blue!50, dashed] (0.5,1.0) -- (8.2,1.0); \node[font=\tiny, text=blue!60, above] at (4.3,1.0) {Toward hybrid analytical+learned models};
 \end{tikzpicture}%
 }
 \caption{Evolution of performance modeling tools (2016--2026).}
@@ -108,17 +108,12 @@ We exclude proprietary tools (NVIDIA Nsight~\cite{nsightcompute2019}, Google TPU
 ML workloads are computation graphs with statically known operator shapes amenable to analytical modeling, though MoE and dynamic inference introduce input-dependent control flow~\cite{pytorch2019,tensorflow2016}.
 Performance depends on dataflow/tiling, KV cache management~\cite{vllm2023}, and compute--memory--network interactions across data, tensor, pipeline, and expert parallelism~\cite{llama3scaling2025}; LLM inference splits into compute-bound prefill and memory-bound decode~\cite{splitwise2024}, modeled under batched serving~\cite{sarathi2024,orca2022}.
 
-Five methodology types span accuracy--speed trade-offs:
-\textbf{analytical}~\cite{williams2009roofline} ($\mu$s, closed-form),
-\textbf{cycle-accurate}~\cite{gpgpusim2009,accelsim2020} ($10^3$--$10^4\times$ slowdown),
-\textbf{trace-driven}~\cite{astrasim2023,vidur2024} (orders-of-magnitude faster),
-\textbf{ML-augmented}~\cite{nnmeter2021} (ms, limited generalization), and
-\textbf{hybrid}~\cite{neusight2025,habitat2021} (analytical structure with learned components).
+Five methodology types span accuracy--speed trade-offs: \textbf{analytical}~\cite{williams2009roofline} ($\mu$s), \textbf{cycle-accurate}~\cite{gpgpusim2009,accelsim2020} ($10^3$--$10^4\times$ slowdown), \textbf{trace-driven}~\cite{astrasim2023,vidur2024} (minutes), \textbf{ML-augmented}~\cite{nnmeter2021} (ms, limited generalization), and \textbf{hybrid}~\cite{neusight2025,habitat2021} (analytical structure with learned components).
 
 \section{Taxonomy}
 \label{sec:taxonomy}
 
-We organize the literature by \emph{methodology type}, \emph{target platform}, and \emph{abstraction level} (Table~\ref{tab:taxonomy-matrix}); a temporal validation lag persists (pre-2023 CNNs, post-2023 transformers/LLMs).
+We organize the literature by \emph{methodology type}, \emph{target platform}, and \emph{abstraction level} (Table~\ref{tab:taxonomy-matrix}).
 
 \begin{table*}[t]
 \centering
@@ -139,24 +134,24 @@ Hybrid           & 1 & 2 & \textbf{0} & \textbf{0} & 1 & ms & Mixed & Med. & Tra
 \end{tabular}
 \end{table*}
 
-Three structural gaps emerge (Figure~\ref{fig:tool-architecture}): trace-driven replay is exclusive to distributed systems, edge devices lack hybrid alternatives, and no ML-augmented tool targets distributed systems.
+Three gaps emerge (Figure~\ref{fig:tool-architecture}): trace-driven replay is exclusive to distributed systems, edge devices lack hybrid alternatives, and no ML-augmented tool targets distributed systems.
 
 \begin{figure}[t]
 \centering
 \resizebox{\columnwidth}{!}{%
-\begin{tikzpicture}[comp/.style={draw=black!60, rounded corners=3pt, minimum width=2.4cm, minimum height=0.65cm, align=center, font=\scriptsize}, input/.style={draw=black!40, dashed, rounded corners=2pt, minimum width=1.8cm, minimum height=0.5cm, align=center, font=\tiny}, arr/.style={-{Stealth[length=3pt]}, thick, black!50}, lbl/.style={font=\tiny, text=black!50}]
-\node[input] (wl) at (0,4) {Workload\\(ONNX/Chakra)}; \node[input] (hw) at (3,4) {Hardware\\config}; \node[input] (prof) at (6,4) {Profiling\\data};
-\node[comp, fill=blue!15] (analytical) at (0,2.5) {Analytical\\Engine}; \node[comp, fill=red!15] (simulator) at (3,2.5) {Cycle-Accurate\\Simulator}; \node[comp, fill=purple!15] (mlmodel) at (6,2.5) {ML Cost\\Model};
-\node[comp, fill=green!15, minimum width=3.2cm] (hybrid) at (3,1) {Hybrid Composition\\(analytical + learned)};
-\node[comp, fill=orange!15, minimum width=6.5cm] (system) at (3,-0.3) {System Orchestrator (trace-driven)};
-\node[input, draw=black!60, fill=gray!10] (output) at (3,-1.5) {Latency / Energy / Throughput};
+\begin{tikzpicture}[comp/.style={draw=black!60, rounded corners=3pt, minimum width=2.4cm, minimum height=0.55cm, align=center, font=\scriptsize}, input/.style={draw=black!40, dashed, rounded corners=2pt, minimum width=1.8cm, minimum height=0.4cm, align=center, font=\tiny}, arr/.style={-{Stealth[length=3pt]}, thick, black!50}, lbl/.style={font=\tiny, text=black!50}]
+\node[input] (wl) at (0,3.3) {Workload\\(ONNX/Chakra)}; \node[input] (hw) at (3,3.3) {Hardware\\config}; \node[input] (prof) at (6,3.3) {Profiling\\data};
+\node[comp, fill=blue!15] (analytical) at (0,2.1) {Analytical\\Engine}; \node[comp, fill=red!15] (simulator) at (3,2.1) {Cycle-Accurate\\Simulator}; \node[comp, fill=purple!15] (mlmodel) at (6,2.1) {ML Cost\\Model};
+\node[comp, fill=green!15, minimum width=3.2cm] (hybrid) at (3,0.9) {Hybrid Composition\\(analytical + learned)};
+\node[comp, fill=orange!15, minimum width=6.5cm] (system) at (3,-0.15) {System Orchestrator (trace-driven)};
+\node[input, draw=black!60, fill=gray!10] (output) at (3,-1.1) {Latency / Energy / Throughput};
 \draw[arr] (wl) -- (analytical); \draw[arr] (hw) -- (analytical); \draw[arr] (hw) -- (simulator); \draw[arr] (wl) -- (simulator); \draw[arr] (prof) -- (mlmodel); \draw[arr] (wl) -- (mlmodel);
 \draw[arr] (analytical) -- (hybrid); \draw[arr] (mlmodel) -- (hybrid); \draw[arr, dashed, gray] (simulator) -- node[lbl, right] {validation} (hybrid);
 \draw[arr] (hybrid) -- (system); \draw[arr] (analytical) |- (system); \draw[arr] (system) -- (output);
-\node[font=\tiny, text=blue!60, anchor=east] at (-0.5,2.5) {Timeloop}; \node[font=\tiny, text=blue!60, anchor=east] at (-0.5,2.2) {MAESTRO};
-\node[font=\tiny, text=red!60, anchor=east] at (1.2,2.8) {Accel-Sim}; \node[font=\tiny, text=red!60, anchor=east] at (1.2,2.5) {GPGPU-Sim};
-\node[font=\tiny, text=purple!60, anchor=west] at (7.6,2.5) {nn-Meter}; \node[font=\tiny, text=purple!60, anchor=west] at (7.6,2.2) {TVM};
-\node[font=\tiny, text=green!50!black, anchor=west] at (5,1) {NeuSight, Habitat}; \node[font=\tiny, text=orange!60!black, anchor=west] at (6.7,-0.3) {ASTRA-sim, VIDUR};
+\node[font=\tiny, text=blue!60, anchor=east] at (-0.5,2.1) {Timeloop, MAESTRO};
+\node[font=\tiny, text=red!60, anchor=east] at (1.2,2.4) {Accel-Sim, GPGPU-Sim};
+\node[font=\tiny, text=purple!60, anchor=west] at (7.6,2.1) {nn-Meter, TVM};
+\node[font=\tiny, text=green!50!black, anchor=west] at (5,0.9) {NeuSight, Habitat}; \node[font=\tiny, text=orange!60!black, anchor=west] at (6.7,-0.15) {ASTRA-sim, VIDUR};
 \end{tikzpicture}%
 }
 \caption{Unified architecture showing how tool methodologies compose.}
@@ -165,27 +160,27 @@ Three structural gaps emerge (Figure~\ref{fig:tool-architecture}): trace-driven 
 
 \textbf{Methodology--platform pairings.}
 \label{subsec:by-methodology}
-Platform constrains methodology: accelerators use analytical models~\cite{timeloop2019,maestro2019}; GPUs span all five types; distributed systems require trace-driven simulation~\cite{astrasim2023,vidur2024}; edge devices rely on ML-augmented approaches~\cite{nnmeter2021,litepred2024}; CPUs~\cite{concorde2025,granite2022} are least studied.
+Platform constrains methodology: accelerators use analytical models~\cite{timeloop2019,maestro2019}; GPUs span all five types; distributed systems require trace-driven simulation~\cite{astrasim2023,vidur2024}; edge devices rely on ML-augmented approaches~\cite{nnmeter2021,litepred2024}; CPUs~\cite{concorde2025,granite2022} remain least studied.
 Errors propagate through the abstraction hierarchy (Figure~\ref{fig:abstraction-levels}): kernel 2--3\%, model 5--12\%, system 5--15\%.
 
 \begin{figure}[t]
 \centering
 \resizebox{\columnwidth}{!}{%
-\begin{tikzpicture}[level/.style={draw, rounded corners=3pt, minimum width=3.2cm, minimum height=0.7cm, align=center, font=\small\bfseries}, tool/.style={font=\scriptsize, text=black!70}, err/.style={font=\scriptsize\itshape, text=red!70!black}, arrow/.style={-{Stealth[length=3pt]}, thick, gray!60}, compos/.style={-{Stealth[length=4pt]}, thick, red!50!black, dashed}]
-\node[level, fill=blue!15, draw=blue!50] (kernel) at (0,0) {Kernel / Operator}; \node[level, fill=green!15, draw=green!50] (model) at (0,1.6) {Model / End-to-End}; \node[level, fill=orange!15, draw=orange!50] (system) at (0,3.2) {System};
+\begin{tikzpicture}[level/.style={draw, rounded corners=3pt, minimum width=3.2cm, minimum height=0.6cm, align=center, font=\small\bfseries}, tool/.style={font=\scriptsize, text=black!70}, err/.style={font=\scriptsize\itshape, text=red!70!black}, arrow/.style={-{Stealth[length=3pt]}, thick, gray!60}, compos/.style={-{Stealth[length=4pt]}, thick, red!50!black, dashed}]
+\node[level, fill=blue!15, draw=blue!50] (kernel) at (0,0) {Kernel / Operator}; \node[level, fill=green!15, draw=green!50] (model) at (0,1.3) {Model / End-to-End}; \node[level, fill=orange!15, draw=orange!50] (system) at (0,2.6) {System};
 \draw[arrow] (kernel) -- (model); \draw[arrow] (model) -- (system);
-\node[tool, anchor=east] at (-2.1,0) {NeuSight, nn-Meter,}; \node[tool, anchor=east] at (-2.1,-0.3) {TVM, GRANITE, TLP}; \node[tool, anchor=east] at (-2.1,1.6) {Paleo, Habitat,}; \node[tool, anchor=east] at (-2.1,1.3) {AMALI, Lumos, LIFE}; \node[tool, anchor=east] at (-2.1,3.2) {ASTRA-sim, VIDUR,}; \node[tool, anchor=east] at (-2.1,2.9) {SimAI, Frontier};
-\node[err, anchor=west] at (2.1,0) {2--3\% error}; \node[err, anchor=west] at (2.1,1.6) {5--12\% error}; \node[err, anchor=west] at (2.1,3.2) {5--15\% error};
-\draw[compos] (3.6,0.2) -- (3.6,3.0); \node[font=\scriptsize, text=red!50!black, rotate=90, anchor=south] at (3.9,1.6) {error accumulates};
+\node[tool, anchor=east] at (-2.1,0) {NeuSight, nn-Meter,}; \node[tool, anchor=east] at (-2.1,-0.25) {TVM, GRANITE, TLP}; \node[tool, anchor=east] at (-2.1,1.3) {Paleo, Habitat,}; \node[tool, anchor=east] at (-2.1,1.05) {AMALI, Lumos, LIFE}; \node[tool, anchor=east] at (-2.1,2.6) {ASTRA-sim, VIDUR,}; \node[tool, anchor=east] at (-2.1,2.35) {SimAI, Frontier};
+\node[err, anchor=west] at (2.1,0) {2--3\% error}; \node[err, anchor=west] at (2.1,1.3) {5--12\% error}; \node[err, anchor=west] at (2.1,2.6) {5--15\% error};
+\draw[compos] (3.6,0.15) -- (3.6,2.45); \node[font=\scriptsize, text=red!50!black, rotate=90, anchor=south] at (3.9,1.3) {error accumulates};
 \end{tikzpicture}%
 }
-\caption{Abstraction level hierarchy with error accumulation across levels.}
+\caption{Abstraction level hierarchy with error accumulation.}
 \label{fig:abstraction-levels}
 \end{figure}
 
 \textbf{Workload coverage.}
 \label{subsec:workload-coverage}
-Of 14 tools, 9 validate on CNNs; post-2023 tools target transformers/LLMs but \textbf{no tool validates on diffusion models or dynamic inference}~\cite{dynamicreasoning2026}, only Frontier~\cite{frontier2025} validates MoE, and none spans the full kernel-to-system stack.
+Of 14 tools, 9 validate only on CNNs; post-2023 tools target transformers/LLMs but \textbf{none validates on diffusion models or dynamic inference}~\cite{dynamicreasoning2026}, only Frontier~\cite{frontier2025} validates MoE, and none spans the full kernel-to-system stack.
 
 \section{Survey of Approaches}
 \label{sec:survey}
@@ -236,18 +231,13 @@ TLP~\cite{tlp2023} & GPU & M & Tensor program & $<$10\% & ms & Transformer cost 
 \end{tabular}
 \end{table*}
 
-\textbf{DNN accelerators.}
-Computational regularity~\cite{sze2017efficient} enables analytical tractability~\cite{diannao2014,eyeriss2016}: Timeloop~\cite{timeloop2019} enumerates loop-nest mappings (5--10\% error); MAESTRO~\cite{maestro2019} offers a compact data-centric representation; Sparseloop~\cite{sparseloop2022} extends to sparse tensors; PyTorchSim~\cite{pytorchsim2025}, ArchGym~\cite{archgym2023}, and PIM tools~\cite{upimulator2024,attacc2024,neupims2024,paise2025} represent newer approaches.
+\textbf{DNN accelerators and GPUs.}
+Computational regularity~\cite{sze2017efficient} enables analytical tractability~\cite{diannao2014,eyeriss2016}: Timeloop~\cite{timeloop2019} enumerates loop-nest mappings (5--10\% error); MAESTRO~\cite{maestro2019} and Sparseloop~\cite{sparseloop2022} extend to data-centric directives and sparse tensors; PyTorchSim~\cite{pytorchsim2025}, ArchGym~\cite{archgym2023}, and PIM tools~\cite{upimulator2024,attacc2024,neupims2024,paise2025} represent newer approaches.
+For GPUs, cycle-accurate simulators (GPGPU-Sim~\cite{gpgpusim2009}, Accel-Sim~\cite{accelsim2020}) achieve 0.90--0.97 IPC correlation at $10^3$--$10^4\times$ slowdown~\cite{dramsim3_2020,ramulator2_2023,dissectinggpu2025}; hybrid and ML-augmented tools---NeuSight~\cite{neusight2025} (2.3\%), Habitat~\cite{habitat2021} (11.8\%), AMALI~\cite{amali2025} (23.6\%), TVM~\cite{tvm2018}/Ansor~\cite{ansor2020}, TLP~\cite{tlp2023}~\cite{life2025,hermes2025,omniwise2025,swizzleperf2025,synperf2025,tenset2021}---trade accuracy for speed.
 
-\textbf{GPUs.}
-Cycle-accurate simulators (GPGPU-Sim~\cite{gpgpusim2009}, Accel-Sim~\cite{accelsim2020}) achieve 0.90--0.97 IPC correlation at $10^3$--$10^4\times$ slowdown~\cite{dramsim3_2020,ramulator2_2023,dissectinggpu2025}.
-NeuSight~\cite{neusight2025} achieves 2.3\% MAPE via tile-based decomposition; AMALI~\cite{amali2025} averages data movement (23.6\%); Habitat~\cite{habitat2021} transfers across GPUs (11.8\%); TVM~\cite{tvm2018}/Ansor~\cite{ansor2020}, TLP~\cite{tlp2023}, and recent tools~\cite{life2025,hermes2025,omniwise2025,swizzleperf2025,synperf2025,tenset2021} target inference and autotuning.
-
-\textbf{Distributed training and LLM serving.}
-VIDUR~\cite{vidur2024} models at the \emph{request level}; ASTRA-sim~\cite{astrasim2023} replays Chakra traces~\cite{chakra2023} at the \emph{collective level} (5--15\%); SimAI~\cite{simai2025} models NCCL-level reductions (1.9\%); Lumos~\cite{lumos2025} (3.3\%), Echo~\cite{echo2024}, Paleo~\cite{paleo2017}, and serving tools~\cite{distserve2024,frontier2025,podattention2025,aqua2025,throttllem2025,sailor2025} provide complementary coverage.
-
-\textbf{Edge devices.}
-nn-Meter~\cite{nnmeter2021} claims $<$1\% but is unverifiable (Section~\ref{sec:eval-results}); LitePred~\cite{litepred2024} achieves 0.7\% across 85 platforms; HELP~\cite{help2021} reaches 1.9\% with 10-sample meta-learning~\cite{esm2025,latencypredictorsnas2024}.
+\textbf{Distributed, serving, and edge.}
+ASTRA-sim~\cite{astrasim2023} replays Chakra traces~\cite{chakra2023} (5--15\%); SimAI~\cite{simai2025} models NCCL reductions (1.9\%); VIDUR~\cite{vidur2024} models request-level LLM serving; Lumos~\cite{lumos2025} (3.3\%), Echo~\cite{echo2024}, Paleo~\cite{paleo2017}, and other serving tools~\cite{distserve2024,frontier2025,podattention2025,aqua2025,throttllem2025,sailor2025} provide complementary coverage.
+For edge, nn-Meter~\cite{nnmeter2021} claims $<$1\% but is unverifiable (Section~\ref{sec:eval-results}); LitePred~\cite{litepred2024} achieves 0.7\% across 85 platforms; HELP~\cite{help2021} reaches 1.9\% with 10-sample meta-learning~\cite{esm2025,latencypredictorsnas2024}.
 \section{Evaluation Methodology}
 \label{sec:eval-framework}
 
@@ -1032,35 +1022,30 @@ Future versions should expand to at least 40 scenarios to maintain coverage as t
 \label{sec:unified-pipeline}
 
 No single tool spans kernel execution through distributed training to serving SLAs (Table~\ref{tab:feature-matrix}).
-We propose a five-layer pipeline (Figure~\ref{fig:pipeline-architecture}):
-(1)~\textbf{Hardware design} (Timeloop): dataflow/mapping DSE for per-layer energy and latency;
-(2)~\textbf{Kernel prediction} (NeuSight/Timeloop): per-kernel execution time on GPUs or custom architectures;
-(3)~\textbf{Model composition} (\textbf{CRITICAL GAP}): compose kernel predictions into full iteration time---\emph{no existing tool validates this layer};
-(4)~\textbf{Distributed training} (ASTRA-sim): multi-GPU communication and topology effects;
-(5)~\textbf{Serving system} (VIDUR): request scheduling, batching, KV cache, and queuing for TTFT/TPOT.
+We propose a five-layer pipeline (Figure~\ref{fig:pipeline-architecture}): (1)~hardware design (Timeloop), (2)~kernel prediction (NeuSight), (3)~\textbf{model composition (CRITICAL GAP---no tool validates this layer)}, (4)~distributed training (ASTRA-sim), and (5)~serving system (VIDUR).
 
 \begin{figure}[t]
 \centering
 \resizebox{\columnwidth}{!}{%
-\begin{tikzpicture}[layer/.style={draw=black!60, rounded corners=3pt, minimum width=5.5cm, minimum height=0.7cm, align=center, font=\scriptsize\bfseries}, tool/.style={font=\tiny, text=black!60}, arr/.style={-{Stealth[length=3pt]}, thick, black!50}, data/.style={font=\tiny\itshape, text=blue!50!black}]
+\begin{tikzpicture}[layer/.style={draw=black!60, rounded corners=3pt, minimum width=5.5cm, minimum height=0.6cm, align=center, font=\scriptsize\bfseries}, tool/.style={font=\tiny, text=black!60}, arr/.style={-{Stealth[length=3pt]}, thick, black!50}, data/.style={font=\tiny\itshape, text=blue!50!black}]
 \node[layer, fill=purple!12, draw=purple!40] (hw) at (0,0) {Layer 1: Hardware Design}; \node[tool, anchor=west] at (3.2,0) {Timeloop};
-\node[layer, fill=blue!12, draw=blue!40] (kernel) at (0,1.3) {Layer 2: Kernel Prediction}; \node[tool, anchor=west] at (3.2,1.3) {NeuSight};
-\node[layer, fill=red!8, draw=red!60, dashed, line width=1pt] (comp) at (0,2.6) {Layer 3: Model Composition}; \node[font=\tiny\bfseries, text=red!60!black, anchor=west] at (3.2,2.6) {CRITICAL GAP};
-\node[layer, fill=orange!12, draw=orange!40] (dist) at (0,3.9) {Layer 4: Distributed Training}; \node[tool, anchor=west] at (3.2,3.9) {ASTRA-sim};
-\node[layer, fill=green!12, draw=green!40] (serve) at (0,5.2) {Layer 5: Serving System}; \node[tool, anchor=west] at (3.2,5.2) {VIDUR};
+\node[layer, fill=blue!12, draw=blue!40] (kernel) at (0,1.1) {Layer 2: Kernel Prediction}; \node[tool, anchor=west] at (3.2,1.1) {NeuSight};
+\node[layer, fill=red!8, draw=red!60, dashed, line width=1pt] (comp) at (0,2.2) {Layer 3: Model Composition}; \node[font=\tiny\bfseries, text=red!60!black, anchor=west] at (3.2,2.2) {CRITICAL GAP};
+\node[layer, fill=orange!12, draw=orange!40] (dist) at (0,3.3) {Layer 4: Distributed Training}; \node[tool, anchor=west] at (3.2,3.3) {ASTRA-sim};
+\node[layer, fill=green!12, draw=green!40] (serve) at (0,4.4) {Layer 5: Serving System}; \node[tool, anchor=west] at (3.2,4.4) {VIDUR};
 \draw[arr] (hw) -- node[data, right, xshift=2pt] {energy, latency} (kernel); \draw[arr] (kernel) -- node[data, right, xshift=2pt] {per-kernel time} (comp);
-\draw[arr, draw=red!50, dashed] (comp) -- node[data, right, xshift=2pt, text=red!50!black] {model iteration time} (dist); \draw[arr] (dist) -- node[data, right, xshift=2pt] {per-device throughput} (serve);
-\node[font=\tiny, text=black!50, anchor=east] at (-3.2,0) {5--10\% RTL err}; \node[font=\tiny, text=black!50, anchor=east] at (-3.2,1.3) {2--9\% MAPE}; \node[font=\tiny, text=red!60!black, anchor=east] at (-3.2,2.6) {\textbf{5--15\% gap}};
-\node[font=\tiny, text=black!50, anchor=east] at (-3.2,3.9) {5--15\% geo.}; \node[font=\tiny, text=black!50, anchor=east] at (-3.2,5.2) {$<$5\% err};
-\draw[decorate, decoration={brace, amplitude=4pt, mirror}, thick, red!50] (-3.4,2.2) -- (-3.4,3.0); \node[font=\tiny, text=red!50!black, anchor=east] at (-3.8,2.6) {unmodeled};
+\draw[arr, draw=red!50, dashed] (comp) -- node[data, right, xshift=2pt, text=red!50!black] {iteration time} (dist); \draw[arr] (dist) -- node[data, right, xshift=2pt] {throughput} (serve);
+\node[font=\tiny, text=black!50, anchor=east] at (-3.2,0) {5--10\% err}; \node[font=\tiny, text=black!50, anchor=east] at (-3.2,1.1) {2--9\% MAPE}; \node[font=\tiny, text=red!60!black, anchor=east] at (-3.2,2.2) {\textbf{5--15\% gap}};
+\node[font=\tiny, text=black!50, anchor=east] at (-3.2,3.3) {5--15\% geo.}; \node[font=\tiny, text=black!50, anchor=east] at (-3.2,4.4) {$<$5\% err};
+\draw[decorate, decoration={brace, amplitude=4pt, mirror}, thick, red!50] (-3.4,1.85) -- (-3.4,2.55); \node[font=\tiny, text=red!50!black, anchor=east] at (-3.8,2.2) {unmodeled};
 \end{tikzpicture}%
 }
-\caption{Proposed unified simulation pipeline across five layers. Layer~3 (model composition, dashed red border) is the critical gap: no existing tool validates the kernel-to-model composition step, where 5--15\% error is introduced by unmodeled inter-kernel overheads.}
+\caption{Unified pipeline across five layers. Layer~3 (dashed) is the critical gap where 5--15\% unmodeled error accumulates.}
 \label{fig:pipeline-architecture}
 \end{figure}
 
-\textbf{The critical gap} is kernel-to-model composition: NeuSight's 5--9\% kernel MAPE grows to 10--28\% at model level via launch overhead, data movement, and synchronization---a gap \emph{larger than kernel-level error}.
-Realizing this pipeline requires a common workload format, validated composition models with formal error bounds, and cross-hardware transfer methods (accuracy degrades $3$--$4\times$ outside training distributions).
+\textbf{The critical gap} is kernel-to-model composition: NeuSight's 5--9\% kernel MAPE grows to 10--28\% at model level via launch overhead, data movement, and synchronization.
+Realizing this pipeline requires common workload formats, validated composition models, and cross-hardware transfer methods (accuracy degrades $3$--$4\times$ outside training distributions).
 
 \section{Open Challenges and Future Directions}
 \label{sec:challenges}
@@ -1071,18 +1056,18 @@ Our evaluation exposes six research directions.
 \begin{figure}[t]
 \centering
 \resizebox{\columnwidth}{!}{%
-\begin{tikzpicture}[box/.style={draw=black!60, rounded corners=2pt, minimum width=1.2cm, minimum height=0.5cm, align=center, font=\tiny}, err/.style={font=\tiny\itshape, text=red!60!black}, arr/.style={-{Stealth[length=3pt]}, thick, black!50}, brace/.style={decorate, decoration={brace, amplitude=4pt, mirror}, thick, black!40}]
+\begin{tikzpicture}[box/.style={draw=black!60, rounded corners=2pt, minimum width=1.2cm, minimum height=0.45cm, align=center, font=\tiny}, err/.style={font=\tiny\itshape, text=red!60!black}, arr/.style={-{Stealth[length=3pt]}, thick, black!50}, brace/.style={decorate, decoration={brace, amplitude=4pt, mirror}, thick, black!40}]
 \node[box, fill=blue!10] (k1) at (0,0) {Conv}; \node[box, fill=blue!10] (k2) at (1.5,0) {Attn}; \node[box, fill=blue!10] (k3) at (3,0) {FFN}; \node[box, fill=blue!10] (k4) at (4.5,0) {Norm}; \node[box, fill=blue!10] (k5) at (6,0) {Softmax};
-\node[err] at (0,-0.55) {2.3\%}; \node[err] at (1.5,-0.55) {2.1\%}; \node[err] at (3,-0.55) {1.8\%}; \node[err] at (4.5,-0.55) {3.5\%}; \node[err] at (6,-0.55) {2.0\%};
+\node[err] at (0,-0.5) {2.3\%}; \node[err] at (1.5,-0.5) {2.1\%}; \node[err] at (3,-0.5) {1.8\%}; \node[err] at (4.5,-0.5) {3.5\%}; \node[err] at (6,-0.5) {2.0\%};
 \node[font=\scriptsize\bfseries, anchor=east] at (-0.8,0) {Kernel};
 \draw[arr] (0.5,0) -- (1,0); \draw[arr] (2,0) -- (2.5,0); \draw[arr] (3.5,0) -- (4,0); \draw[arr] (5,0) -- (5.5,0);
-\node[box, fill=yellow!20, dashed, draw=orange!60] (h1) at (0.75,0.8) {Launch\\overhead}; \node[box, fill=yellow!20, dashed, draw=orange!60] (h2) at (2.25,0.8) {Mem\\alloc}; \node[box, fill=yellow!20, dashed, draw=orange!60] (h3) at (3.75,0.8) {Data\\movement}; \node[box, fill=yellow!20, dashed, draw=orange!60] (h4) at (5.25,0.8) {Sync\\barrier};
-\node[box, fill=green!10, minimum width=6.5cm] (model) at (3,1.9) {Model-level prediction}; \node[err] at (3,1.4) {5--12\% (hidden overhead accumulates)}; \node[font=\scriptsize\bfseries, anchor=east] at (-0.8,1.9) {Model};
-\node[box, fill=orange!10, minimum width=6.5cm] (system) at (3,3.0) {System-level prediction}; \node[err] at (3,2.5) {+ communication, scheduling, contention}; \node[font=\scriptsize\bfseries, anchor=east] at (-0.8,3.0) {System}; \node[err] at (3,3.55) {5--15\% total error};
-\draw[brace] (-0.5,-0.8) -- (6.5,-0.8) node[midway, below=5pt, font=\tiny, text=red!60!black] {$\sigma_{\text{model}} \approx \sigma_{\text{kernel}} \cdot \sqrt{N}$ (uncorrelated) to $N \cdot \sigma_{\text{kernel}}$ (correlated)};
+\node[box, fill=yellow!20, dashed, draw=orange!60] (h1) at (0.75,0.7) {Launch\\overhead}; \node[box, fill=yellow!20, dashed, draw=orange!60] (h2) at (2.25,0.7) {Mem\\alloc}; \node[box, fill=yellow!20, dashed, draw=orange!60] (h3) at (3.75,0.7) {Data\\movement}; \node[box, fill=yellow!20, dashed, draw=orange!60] (h4) at (5.25,0.7) {Sync\\barrier};
+\node[box, fill=green!10, minimum width=6.5cm] (model) at (3,1.6) {Model-level prediction}; \node[err] at (3,1.15) {5--12\% (hidden overhead accumulates)}; \node[font=\scriptsize\bfseries, anchor=east] at (-0.8,1.6) {Model};
+\node[box, fill=orange!10, minimum width=6.5cm] (system) at (3,2.55) {System-level prediction}; \node[err] at (3,2.1) {+ communication, scheduling, contention}; \node[font=\scriptsize\bfseries, anchor=east] at (-0.8,2.55) {System}; \node[err] at (3,3.0) {5--15\% total error};
+\draw[brace] (-0.5,-0.75) -- (6.5,-0.75) node[midway, below=4pt, font=\tiny, text=red!60!black] {$\sigma_{\text{model}} \approx \sigma_{\text{kernel}} \cdot \sqrt{N}$ (uncorrelated) to $N \cdot \sigma_{\text{kernel}}$ (correlated)};
 \end{tikzpicture}%
 }
-\caption{Error composition: kernel predictions (2--3\%) accumulate to 5--12\% model-level and 5--15\% system-level error.}
+\caption{Error composition: kernel predictions (2--3\%) accumulate to 5--15\% at system level.}
 \label{fig:error-composition}
 \end{figure}
 
@@ -1092,7 +1077,7 @@ Our evaluation exposes six research directions.
 \centering
 \resizebox{\columnwidth}{!}{%
 \begin{tikzpicture}
-\begin{axis}[ybar stacked, bar width=14pt, xlabel={Publication year}, ylabel={Number of tools}, ymin=0, ymax=16, xtick={2016,2018,2020,2022,2024,2026}, xticklabels={2016--17,2018--19,2020--21,2022--23,2024--25,2026}, xticklabel style={font=\scriptsize}, yticklabel style={font=\scriptsize}, xlabel style={font=\small}, ylabel style={font=\small}, legend style={at={(0.02,0.98)}, anchor=north west, font=\tiny, draw=none, fill=white, fill opacity=0.9, text opacity=1, legend columns=2}, legend cell align={left}, height=5.5cm, width=8.5cm, enlarge x limits={abs=0.8cm}]
+\begin{axis}[ybar stacked, bar width=14pt, xlabel={Publication year}, ylabel={Number of tools}, ymin=0, ymax=16, xtick={2016,2018,2020,2022,2024,2026}, xticklabels={2016--17,2018--19,2020--21,2022--23,2024--25,2026}, xticklabel style={font=\scriptsize}, yticklabel style={font=\scriptsize}, xlabel style={font=\small}, ylabel style={font=\small}, legend style={at={(0.02,0.98)}, anchor=north west, font=\tiny, draw=none, fill=white, fill opacity=0.9, text opacity=1, legend columns=2}, legend cell align={left}, height=4.5cm, width=8.5cm, enlarge x limits={abs=0.8cm}]
 \addplot[fill=blue!50, draw=blue!70] coordinates {(2016,2) (2018,2) (2020,4) (2022,3) (2024,2) (2026,0)};
 \addplot[fill=orange!50, draw=orange!70] coordinates {(2016,0) (2018,1) (2020,0) (2022,2) (2024,3) (2026,0)};
 \addplot[fill=red!50, draw=red!70] coordinates {(2016,0) (2018,0) (2020,1) (2022,1) (2024,8) (2026,2)};
@@ -1105,10 +1090,8 @@ Our evaluation exposes six research directions.
 \label{fig:workload-coverage}
 \end{figure}
 
-\textbf{(3)~Hardware transfer:} Cross-family transfer (GPU$\rightarrow$TPU$\rightarrow$PIM) remains unsolved; PIM~\cite{upimulator2024,attacc2024,neupims2024,paise2025}, chiplets, and disaggregated designs blur memory hierarchy assumptions.
-\textbf{(4)~Network fidelity:} Current tools~\cite{astrasim2023,triosim2025} use analytical network abstractions, omitting packet-level congestion captured by NS-3~\cite{ns3_2010} at orders-of-magnitude slowdown.
-\textbf{(5)~Standardized evaluation:} No MLPerf~\cite{mlperf_training2020,mlperf_inference2020} equivalent exists for prediction; the community needs common benchmarks, portable formats (ONNX, Chakra~\cite{chakra2023}), and Docker-first deployment.
-\textbf{(6)~Temporal stability:} Software evolution (FlashAttention~\cite{flashattention2022}, CUDA updates) silently invalidates models; nn-Meter's failure underscores the need for continuous validation~\cite{mlperfpower2025}.
+\textbf{(3)~Hardware transfer and network fidelity:} Cross-family transfer (GPU$\rightarrow$TPU$\rightarrow$PIM~\cite{upimulator2024,attacc2024,neupims2024,paise2025}) remains unsolved, and current tools~\cite{astrasim2023,triosim2025} use analytical network abstractions omitting congestion captured only by NS-3~\cite{ns3_2010}.
+\textbf{(4)~Standardized evaluation and temporal stability:} No MLPerf~\cite{mlperf_training2020,mlperf_inference2020} equivalent exists for prediction tools---the community needs common benchmarks, portable formats (ONNX, Chakra~\cite{chakra2023}), Docker-first deployment, and continuous validation~\cite{mlperfpower2025} (nn-Meter's dependency rot exemplifies model invalidation by software evolution~\cite{flashattention2022}).
 
 \section{Conclusion}
 \label{sec:conclusion}


### PR DESCRIPTION
## Summary
- Cut 17 raw lines from non-eval sections (1122→1105) plus significant rendered-space savings from TikZ figure compaction across 5 figures
- Merged platform paragraphs in Survey of Approaches (4→2), compressed pipeline description, consolidated Open Challenges (6→4)
- Reduced vertical spacing in 5 TikZ figures: tool-architecture, abstraction-levels, pipeline-architecture, error-composition, workload-coverage
- All citations preserved, all 8 figures preserved, Sections 6-7 untouched

## Changes by section
- **Introduction**: tightened itemize wording
- **Background**: merged methodology types into single sentence  
- **Taxonomy**: shortened intro, tightened prose, compacted Fig 2 and Fig 3
- **Survey of Approaches**: merged 4 platform paragraphs into 2
- **Unified Pipeline**: inline 5-layer list, compacted Fig 5, shorter caption
- **Open Challenges**: merged 6 challenges into 4, compacted Fig 6 and Fig 7

## Test plan
- [ ] Verify LaTeX compiles without errors
- [ ] Check rendered page count reduction
- [ ] Verify all figures render correctly with reduced spacing
- [ ] Confirm no citations or figures were removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)