### PR TITLE
Fourth compression pass: TikZ/table compaction + prose cuts

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -37,6 +37,7 @@
 
 %% Additional packages (acmart already loads amsmath, amsfonts, amssymb, booktabs)
 \usepackage{multirow}
+\usepackage{enumitem}
 \usepackage{tikz}
 \usetikzlibrary{shapes.geometric,arrows.meta,positioning,fit,backgrounds,patterns,decorations.pathreplacing}
 \usepackage{pgfplots}
@@ -70,12 +71,12 @@ Third, the kernel-to-model composition gap (2--9\% kernel error growing to 10--2
 \label{sec:introduction}
 
 Domain-specific architectures~\cite{hennessy2019golden,tpuv1_2017,tpuv4_2023} make performance prediction critical for ML workload deployment, yet no prior work examines \emph{why} certain approaches succeed---analytical models~\cite{timeloop2019,maestro2019}, trace-driven simulators~\cite{astrasim2023,vidur2024}, hybrid approaches~\cite{neusight2025}---or how errors propagate across the abstraction stack; existing surveys focus on ML \emph{techniques} for modeling~\cite{granite2022} or specific hardware~\cite{timeloop2019}.
-We contribute an \textbf{accuracy-centered independent verification framework} paired with an \textbf{LLM-focused benchmark suite}, replacing self-reported accuracy with reproducible evaluation revealing claimed error rates are overstated by $2$--$4\times$:
-\begin{itemize}
+We contribute an \textbf{accuracy-centered verification framework} paired with an \textbf{LLM-focused benchmark suite}, replacing self-reported accuracy with reproducible evaluation showing claimed error rates are overstated by $2$--$4\times$:
+\begin{itemize}[noitemsep,topsep=2pt]
 \item A \textbf{28-scenario LLM benchmark suite} spanning training and inference, revealing 50\% of scenarios have zero tool support (Section~\ref{sec:eval-framework}).
-\item \textbf{Independent accuracy verification} of five tools (146 GPU configs, collectives, LLM serving, energy), showing self-reported claims are systematically overstated (Section~\ref{sec:eval-results}).
-\item A \textbf{unified simulation pipeline} across five layers, identifying the kernel-to-model composition gap as the critical missing piece (Section~\ref{sec:unified-pipeline}).
-\item A \textbf{coverage matrix} and \textbf{research agenda} for composition modeling, unified formats, cross-hardware transfer, and continuous validation (Sections~\ref{sec:taxonomy},~\ref{sec:challenges}).
+\item \textbf{Independent accuracy verification} of five tools (146 GPU configs, collectives, LLM serving, energy), showing self-reported claims are overstated (Section~\ref{sec:eval-results}).
+\item A \textbf{unified simulation pipeline} identifying the kernel-to-model composition gap as the critical missing piece (Section~\ref{sec:unified-pipeline}).
+\item A \textbf{coverage matrix} and research agenda for composition modeling, unified formats, and continuous validation (Sections~\ref{sec:taxonomy},~\ref{sec:challenges}).
 \end{itemize}
 
 \begin{figure}[t]
@@ -83,11 +84,11 @@ We contribute an \textbf{accuracy-centered independent verification framework} p
 \resizebox{\columnwidth}{!}{%
 \begin{tikzpicture}[yearnode/.style={font=\scriptsize\bfseries, text=black!70}, eventnode/.style={font=\tiny, text width=2cm, align=center}]
 \draw[thick, ->, black!40] (0,0) -- (9,0);
-\foreach \x/\year in {0.3/2016, 1.5/2018, 3/2020, 4.5/2022, 6/2024, 7.2/2025, 8.5/2026} { \draw[thick, black!40] (\x,-0.1) -- (\x,0.1); \node[yearnode, below] at (\x,-0.15) {\year}; }
-\node[eventnode, above] at (0.3,0.3) {Eyeriss\\Paleo}; \node[eventnode, below] at (1.2,-0.3) {TVM}; \node[eventnode, above] at (2.2,0.3) {Timeloop\\MAESTRO}; \node[eventnode, below] at (3,-0.3) {Ansor\\ASTRA-sim};
-\node[eventnode, above] at (3.8,0.3) {nn-Meter\\Habitat}; \node[eventnode, below] at (4.5,-0.3) {Sparseloop\\Accel-Sim}; \node[eventnode, above] at (5.3,0.3) {TLP\\ASTRA-sim 2.0}; \node[eventnode, below] at (6,-0.3) {VIDUR\\Splitwise};
-\node[eventnode, above] at (7.2,0.3) {NeuSight\\AMALI}; \node[eventnode, below] at (8.5,-0.3) {Frontier\\Lumos};
-\draw[thick, ->, blue!50, dashed] (0.5,1.0) -- (8.2,1.0); \node[font=\tiny, text=blue!60, above] at (4.3,1.0) {Toward hybrid analytical+learned models};
+\foreach \x/\year in {0.3/2016, 1.5/2018, 3/2020, 4.5/2022, 6/2024, 7.2/2025, 8.5/2026} { \draw[thick, black!40] (\x,-0.1) -- (\x,0.1); \node[yearnode, below] at (\x,-0.12) {\year}; }
+\node[eventnode, above] at (0.3,0.2) {Eyeriss\\Paleo}; \node[eventnode, below] at (1.2,-0.2) {TVM}; \node[eventnode, above] at (2.2,0.2) {Timeloop\\MAESTRO}; \node[eventnode, below] at (3,-0.2) {Ansor\\ASTRA-sim};
+\node[eventnode, above] at (3.8,0.2) {nn-Meter\\Habitat}; \node[eventnode, below] at (4.5,-0.2) {Sparseloop\\Accel-Sim}; \node[eventnode, above] at (5.3,0.2) {TLP\\ASTRA-sim 2.0}; \node[eventnode, below] at (6,-0.2) {VIDUR\\Splitwise};
+\node[eventnode, above] at (7.2,0.2) {NeuSight\\AMALI}; \node[eventnode, below] at (8.5,-0.2) {Frontier\\Lumos};
+\draw[thick, ->, blue!50, dashed] (0.5,0.85) -- (8.2,0.85); \node[font=\tiny, text=blue!60, above] at (4.3,0.85) {Toward hybrid analytical+learned models};
 \end{tikzpicture}%
 }
 \caption{Evolution of performance modeling tools (2016--2026).}
@@ -97,18 +98,16 @@ We contribute an \textbf{accuracy-centered independent verification framework} p
 \section{Survey Methodology}
 \label{sec:methodology}
 
-We searched ACM Digital Library, IEEE Xplore, Semantic Scholar, and arXiv, targeting architecture (MICRO, ISCA, HPCA, ASPLOS), systems (MLSys, OSDI, SOSP, NSDI), and related venues.
-From 287 candidates, screening yielded 53 papers (2016--2026) supplemented by 12 foundational works, classified by \emph{methodology type}, \emph{target platform}, and \emph{abstraction level}.
-Prior surveys address ML for processor DSE~\cite{rakhshanfar2021survey}, DNN hardware design~\cite{sze2017efficient}, simulation infrastructure~\cite{gpgpusim2009,binkert2011gem5,sst2012}, and standardized measurement~\cite{mlperf_training2020,mlperf_inference2020}; the closest work~\cite{latencypredictorsnas2024} compares edge predictors for NAS.
-We exclude proprietary tools (NVIDIA Nsight~\cite{nsightcompute2019}, Google TPU models); compiler cost models~\cite{halide2013,mlir2020,triton2019} and cluster schedulers~\cite{pollux2021,sia2023} share techniques but serve distinct use cases.
+We searched ACM DL, IEEE Xplore, Semantic Scholar, and arXiv targeting architecture (MICRO, ISCA, HPCA, ASPLOS), systems (MLSys, OSDI, SOSP, NSDI), and related venues.
+From 287 candidates, 53 papers (2016--2026) plus 12 foundational works were classified by \emph{methodology type}, \emph{target platform}, and \emph{abstraction level}.
+Prior surveys cover ML for processor DSE~\cite{rakhshanfar2021survey}, DNN hardware~\cite{sze2017efficient}, simulation infrastructure~\cite{gpgpusim2009,binkert2011gem5,sst2012}, and measurement~\cite{mlperf_training2020,mlperf_inference2020}; the closest work~\cite{latencypredictorsnas2024} compares edge predictors for NAS.
+We exclude proprietary tools (NVIDIA Nsight~\cite{nsightcompute2019}), compiler cost models~\cite{halide2013,mlir2020,triton2019}, and cluster schedulers~\cite{pollux2021,sia2023}.
 
 \section{Background}
 \label{sec:background}
 
-ML workloads are computation graphs with statically known operator shapes amenable to analytical modeling, though MoE and dynamic inference introduce input-dependent control flow~\cite{pytorch2019,tensorflow2016}.
-Performance depends on dataflow/tiling, KV cache management~\cite{vllm2023}, and compute--memory--network interactions across data, tensor, pipeline, and expert parallelism~\cite{llama3scaling2025}; LLM inference splits into compute-bound prefill and memory-bound decode~\cite{splitwise2024}, modeled under batched serving~\cite{sarathi2024,orca2022}.
-
-Five methodology types span accuracy--speed trade-offs: \textbf{analytical}~\cite{williams2009roofline} ($\mu$s), \textbf{cycle-accurate}~\cite{gpgpusim2009,accelsim2020} ($10^3$--$10^4\times$ slowdown), \textbf{trace-driven}~\cite{astrasim2023,vidur2024} (minutes), \textbf{ML-augmented}~\cite{nnmeter2021} (ms, limited generalization), and \textbf{hybrid}~\cite{neusight2025,habitat2021} (analytical structure with learned components).
+ML workloads are computation graphs with statically known operator shapes amenable to analytical modeling; MoE and dynamic inference add input-dependent control flow~\cite{pytorch2019,tensorflow2016}. Performance depends on dataflow/tiling, KV cache~\cite{vllm2023}, and compute--memory--network interactions; LLM inference splits into compute-bound prefill and memory-bound decode~\cite{splitwise2024,sarathi2024,orca2022}.
+Five methodology types span accuracy--speed trade-offs: \textbf{analytical}~\cite{williams2009roofline} ($\mu$s), \textbf{cycle-accurate}~\cite{gpgpusim2009,accelsim2020} ($10^3$--$10^4\times$ slowdown), \textbf{trace-driven}~\cite{astrasim2023,vidur2024} (min.), \textbf{ML-augmented}~\cite{nnmeter2021} (ms), and \textbf{hybrid}~\cite{neusight2025,habitat2021} (analytical+learned).
 
 \section{Taxonomy}
 \label{sec:taxonomy}
@@ -119,7 +118,7 @@ We organize the literature by \emph{methodology type}, \emph{target platform}, a
 \centering
 \caption{Methodology taxonomy: coverage matrix and trade-off profile. \textbf{0} = research gap.}
 \label{tab:taxonomy-matrix}
-\small
+\footnotesize
 \begin{tabular}{l|ccccc|cccc}
 \toprule
  & \textbf{DNN} & & \textbf{Distrib.} & \textbf{Edge/} & & \textbf{Eval.} & \textbf{Data} & & \textbf{Failure} \\
@@ -134,24 +133,23 @@ Hybrid           & 1 & 2 & \textbf{0} & \textbf{0} & 1 & ms & Mixed & Med. & Tra
 \end{tabular}
 \end{table*}
 
-Three gaps emerge (Figure~\ref{fig:tool-architecture}): trace-driven replay is exclusive to distributed systems, edge devices lack hybrid alternatives, and no ML-augmented tool targets distributed systems.
-
+Three gaps emerge (Figure~\ref{fig:tool-architecture}): trace-driven replay is exclusive to distributed systems, edge devices lack hybrid alternatives, and no ML-augmented tool targets distributed settings.
 \begin{figure}[t]
 \centering
 \resizebox{\columnwidth}{!}{%
-\begin{tikzpicture}[comp/.style={draw=black!60, rounded corners=3pt, minimum width=2.4cm, minimum height=0.55cm, align=center, font=\scriptsize}, input/.style={draw=black!40, dashed, rounded corners=2pt, minimum width=1.8cm, minimum height=0.4cm, align=center, font=\tiny}, arr/.style={-{Stealth[length=3pt]}, thick, black!50}, lbl/.style={font=\tiny, text=black!50}]
-\node[input] (wl) at (0,3.3) {Workload\\(ONNX/Chakra)}; \node[input] (hw) at (3,3.3) {Hardware\\config}; \node[input] (prof) at (6,3.3) {Profiling\\data};
-\node[comp, fill=blue!15] (analytical) at (0,2.1) {Analytical\\Engine}; \node[comp, fill=red!15] (simulator) at (3,2.1) {Cycle-Accurate\\Simulator}; \node[comp, fill=purple!15] (mlmodel) at (6,2.1) {ML Cost\\Model};
-\node[comp, fill=green!15, minimum width=3.2cm] (hybrid) at (3,0.9) {Hybrid Composition\\(analytical + learned)};
+\begin{tikzpicture}[comp/.style={draw=black!60, rounded corners=3pt, minimum width=2.4cm, minimum height=0.45cm, align=center, font=\scriptsize}, input/.style={draw=black!40, dashed, rounded corners=2pt, minimum width=1.8cm, minimum height=0.35cm, align=center, font=\tiny}, arr/.style={-{Stealth[length=3pt]}, thick, black!50}, lbl/.style={font=\tiny, text=black!50}]
+\node[input] (wl) at (0,2.9) {Workload\\(ONNX/Chakra)}; \node[input] (hw) at (3,2.9) {Hardware\\config}; \node[input] (prof) at (6,2.9) {Profiling\\data};
+\node[comp, fill=blue!15] (analytical) at (0,1.8) {Analytical\\Engine}; \node[comp, fill=red!15] (simulator) at (3,1.8) {Cycle-Accurate\\Simulator}; \node[comp, fill=purple!15] (mlmodel) at (6,1.8) {ML Cost\\Model};
+\node[comp, fill=green!15, minimum width=3.2cm] (hybrid) at (3,0.75) {Hybrid Composition\\(analytical + learned)};
 \node[comp, fill=orange!15, minimum width=6.5cm] (system) at (3,-0.15) {System Orchestrator (trace-driven)};
-\node[input, draw=black!60, fill=gray!10] (output) at (3,-1.1) {Latency / Energy / Throughput};
+\node[input, draw=black!60, fill=gray!10] (output) at (3,-0.95) {Latency / Energy / Throughput};
 \draw[arr] (wl) -- (analytical); \draw[arr] (hw) -- (analytical); \draw[arr] (hw) -- (simulator); \draw[arr] (wl) -- (simulator); \draw[arr] (prof) -- (mlmodel); \draw[arr] (wl) -- (mlmodel);
-\draw[arr] (analytical) -- (hybrid); \draw[arr] (mlmodel) -- (hybrid); \draw[arr, dashed, gray] (simulator) -- node[lbl, right] {validation} (hybrid);
+\draw[arr] (analytical) -- (hybrid); \draw[arr] (mlmodel) -- (hybrid); \draw[arr, dashed, gray] (simulator) -- node[lbl, right] {valid.} (hybrid);
 \draw[arr] (hybrid) -- (system); \draw[arr] (analytical) |- (system); \draw[arr] (system) -- (output);
-\node[font=\tiny, text=blue!60, anchor=east] at (-0.5,2.1) {Timeloop, MAESTRO};
-\node[font=\tiny, text=red!60, anchor=east] at (1.2,2.4) {Accel-Sim, GPGPU-Sim};
-\node[font=\tiny, text=purple!60, anchor=west] at (7.6,2.1) {nn-Meter, TVM};
-\node[font=\tiny, text=green!50!black, anchor=west] at (5,0.9) {NeuSight, Habitat}; \node[font=\tiny, text=orange!60!black, anchor=west] at (6.7,-0.15) {ASTRA-sim, VIDUR};
+\node[font=\tiny, text=blue!60, anchor=east] at (-0.5,1.8) {Timeloop, MAESTRO};
+\node[font=\tiny, text=red!60, anchor=east] at (1.2,2.05) {Accel-Sim, GPGPU-Sim};
+\node[font=\tiny, text=purple!60, anchor=west] at (7.6,1.8) {nn-Meter, TVM};
+\node[font=\tiny, text=green!50!black, anchor=west] at (5,0.75) {NeuSight, Habitat}; \node[font=\tiny, text=orange!60!black, anchor=west] at (6.7,-0.15) {ASTRA-sim, VIDUR};
 \end{tikzpicture}%
 }
 \caption{Unified architecture showing how tool methodologies compose.}
@@ -160,18 +158,17 @@ Three gaps emerge (Figure~\ref{fig:tool-architecture}): trace-driven replay is e
 
 \textbf{Methodology--platform pairings.}
 \label{subsec:by-methodology}
-Platform constrains methodology: accelerators use analytical models~\cite{timeloop2019,maestro2019}; GPUs span all five types; distributed systems require trace-driven simulation~\cite{astrasim2023,vidur2024}; edge devices rely on ML-augmented approaches~\cite{nnmeter2021,litepred2024}; CPUs~\cite{concorde2025,granite2022} remain least studied.
-Errors propagate through the abstraction hierarchy (Figure~\ref{fig:abstraction-levels}): kernel 2--3\%, model 5--12\%, system 5--15\%.
+Platform constrains methodology: accelerators use analytical models~\cite{timeloop2019,maestro2019}; GPUs span all five types; distributed systems require trace-driven simulation~\cite{astrasim2023,vidur2024}; edge devices rely on ML-augmented~\cite{nnmeter2021,litepred2024}; CPUs~\cite{concorde2025,granite2022} remain least studied. Errors propagate (Figure~\ref{fig:abstraction-levels}): kernel 2--3\%, model 5--12\%, system 5--15\%.
 
 \begin{figure}[t]
 \centering
 \resizebox{\columnwidth}{!}{%
-\begin{tikzpicture}[level/.style={draw, rounded corners=3pt, minimum width=3.2cm, minimum height=0.6cm, align=center, font=\small\bfseries}, tool/.style={font=\scriptsize, text=black!70}, err/.style={font=\scriptsize\itshape, text=red!70!black}, arrow/.style={-{Stealth[length=3pt]}, thick, gray!60}, compos/.style={-{Stealth[length=4pt]}, thick, red!50!black, dashed}]
-\node[level, fill=blue!15, draw=blue!50] (kernel) at (0,0) {Kernel / Operator}; \node[level, fill=green!15, draw=green!50] (model) at (0,1.3) {Model / End-to-End}; \node[level, fill=orange!15, draw=orange!50] (system) at (0,2.6) {System};
+\begin{tikzpicture}[level/.style={draw, rounded corners=3pt, minimum width=3.2cm, minimum height=0.5cm, align=center, font=\small\bfseries}, tool/.style={font=\scriptsize, text=black!70}, err/.style={font=\scriptsize\itshape, text=red!70!black}, arrow/.style={-{Stealth[length=3pt]}, thick, gray!60}, compos/.style={-{Stealth[length=4pt]}, thick, red!50!black, dashed}]
+\node[level, fill=blue!15, draw=blue!50] (kernel) at (0,0) {Kernel / Operator}; \node[level, fill=green!15, draw=green!50] (model) at (0,1.1) {Model / End-to-End}; \node[level, fill=orange!15, draw=orange!50] (system) at (0,2.2) {System};
 \draw[arrow] (kernel) -- (model); \draw[arrow] (model) -- (system);
-\node[tool, anchor=east] at (-2.1,0) {NeuSight, nn-Meter,}; \node[tool, anchor=east] at (-2.1,-0.25) {TVM, GRANITE, TLP}; \node[tool, anchor=east] at (-2.1,1.3) {Paleo, Habitat,}; \node[tool, anchor=east] at (-2.1,1.05) {AMALI, Lumos, LIFE}; \node[tool, anchor=east] at (-2.1,2.6) {ASTRA-sim, VIDUR,}; \node[tool, anchor=east] at (-2.1,2.35) {SimAI, Frontier};
-\node[err, anchor=west] at (2.1,0) {2--3\% error}; \node[err, anchor=west] at (2.1,1.3) {5--12\% error}; \node[err, anchor=west] at (2.1,2.6) {5--15\% error};
-\draw[compos] (3.6,0.15) -- (3.6,2.45); \node[font=\scriptsize, text=red!50!black, rotate=90, anchor=south] at (3.9,1.3) {error accumulates};
+\node[tool, anchor=east] at (-2.1,0) {NeuSight, nn-Meter,}; \node[tool, anchor=east] at (-2.1,-0.2) {TVM, GRANITE, TLP}; \node[tool, anchor=east] at (-2.1,1.1) {Paleo, Habitat,}; \node[tool, anchor=east] at (-2.1,0.9) {AMALI, Lumos, LIFE}; \node[tool, anchor=east] at (-2.1,2.2) {ASTRA-sim, VIDUR,}; \node[tool, anchor=east] at (-2.1,2.0) {SimAI, Frontier};
+\node[err, anchor=west] at (2.1,0) {2--3\% error}; \node[err, anchor=west] at (2.1,1.1) {5--12\% error}; \node[err, anchor=west] at (2.1,2.2) {5--15\% error};
+\draw[compos] (3.6,0.15) -- (3.6,2.05); \node[font=\scriptsize, text=red!50!black, rotate=90, anchor=south] at (3.9,1.1) {error accumulates};
 \end{tikzpicture}%
 }
 \caption{Abstraction level hierarchy with error accumulation.}
@@ -180,8 +177,7 @@ Errors propagate through the abstraction hierarchy (Figure~\ref{fig:abstraction-
 
 \textbf{Workload coverage.}
 \label{subsec:workload-coverage}
-Of 14 tools, 9 validate only on CNNs; post-2023 tools target transformers/LLMs but \textbf{none validates on diffusion models or dynamic inference}~\cite{dynamicreasoning2026}, only Frontier~\cite{frontier2025} validates MoE, and none spans the full kernel-to-system stack.
-
+Of 14 tools, 9 validate only on CNNs; post-2023 tools target transformers/LLMs but \textbf{none validates on diffusion or dynamic inference}~\cite{dynamicreasoning2026}, only Frontier~\cite{frontier2025} validates MoE, and none spans the full kernel-to-system stack.
 \section{Survey of Approaches}
 \label{sec:survey}
 
@@ -191,7 +187,7 @@ We survey tools by target platform (Table~\ref{tab:survey-summary}).
 \centering
 \caption{Surveyed tools by target platform. A=Analytical, S=Simulation, T=Trace-driven, M=ML-augmented, H=Hybrid. $^*$Surrogate-vs-simulator fidelity. $^\dagger$Unverifiable. $^\ddagger$No hardware baseline.}
 \label{tab:survey-summary}
-\small
+\footnotesize
 \begin{tabular}{lllllll}
 \toprule
 \textbf{Tool} & \textbf{Platform} & \textbf{Method} & \textbf{Target} & \textbf{Accuracy} & \textbf{Speed} & \textbf{Key Capability} \\
@@ -232,12 +228,9 @@ TLP~\cite{tlp2023} & GPU & M & Tensor program & $<$10\% & ms & Transformer cost 
 \end{table*}
 
 \textbf{DNN accelerators and GPUs.}
-Computational regularity~\cite{sze2017efficient} enables analytical tractability~\cite{diannao2014,eyeriss2016}: Timeloop~\cite{timeloop2019} enumerates loop-nest mappings (5--10\% error); MAESTRO~\cite{maestro2019} and Sparseloop~\cite{sparseloop2022} extend to data-centric directives and sparse tensors; PyTorchSim~\cite{pytorchsim2025}, ArchGym~\cite{archgym2023}, and PIM tools~\cite{upimulator2024,attacc2024,neupims2024,paise2025} represent newer approaches.
-For GPUs, cycle-accurate simulators (GPGPU-Sim~\cite{gpgpusim2009}, Accel-Sim~\cite{accelsim2020}) achieve 0.90--0.97 IPC correlation at $10^3$--$10^4\times$ slowdown~\cite{dramsim3_2020,ramulator2_2023,dissectinggpu2025}; hybrid and ML-augmented tools---NeuSight~\cite{neusight2025} (2.3\%), Habitat~\cite{habitat2021} (11.8\%), AMALI~\cite{amali2025} (23.6\%), TVM~\cite{tvm2018}/Ansor~\cite{ansor2020}, TLP~\cite{tlp2023}~\cite{life2025,hermes2025,omniwise2025,swizzleperf2025,synperf2025,tenset2021}---trade accuracy for speed.
-
+Computational regularity~\cite{sze2017efficient} enables analytical tractability~\cite{diannao2014,eyeriss2016}: Timeloop~\cite{timeloop2019} enumerates loop-nest mappings (5--10\%); MAESTRO~\cite{maestro2019} and Sparseloop~\cite{sparseloop2022} extend to data-centric and sparse tensors; PyTorchSim~\cite{pytorchsim2025}, ArchGym~\cite{archgym2023}, and PIM tools~\cite{upimulator2024,attacc2024,neupims2024,paise2025} represent newer approaches. For GPUs, cycle-accurate simulators (GPGPU-Sim~\cite{gpgpusim2009}, Accel-Sim~\cite{accelsim2020}) achieve 0.90--0.97 IPC correlation at $10^3$--$10^4\times$ slowdown~\cite{dramsim3_2020,ramulator2_2023,dissectinggpu2025}; hybrid and ML-augmented tools---NeuSight~\cite{neusight2025} (2.3\%), Habitat~\cite{habitat2021} (11.8\%), AMALI~\cite{amali2025} (23.6\%), TVM~\cite{tvm2018}/Ansor~\cite{ansor2020}/TLP~\cite{tlp2023}~\cite{life2025,hermes2025,omniwise2025,swizzleperf2025,synperf2025,tenset2021}---trade accuracy for speed.
 \textbf{Distributed, serving, and edge.}
-ASTRA-sim~\cite{astrasim2023} replays Chakra traces~\cite{chakra2023} (5--15\%); SimAI~\cite{simai2025} models NCCL reductions (1.9\%); VIDUR~\cite{vidur2024} models request-level LLM serving; Lumos~\cite{lumos2025} (3.3\%), Echo~\cite{echo2024}, Paleo~\cite{paleo2017}, and other serving tools~\cite{distserve2024,frontier2025,podattention2025,aqua2025,throttllem2025,sailor2025} provide complementary coverage.
-For edge, nn-Meter~\cite{nnmeter2021} claims $<$1\% but is unverifiable (Section~\ref{sec:eval-results}); LitePred~\cite{litepred2024} achieves 0.7\% across 85 platforms; HELP~\cite{help2021} reaches 1.9\% with 10-sample meta-learning~\cite{esm2025,latencypredictorsnas2024}.
+ASTRA-sim~\cite{astrasim2023} replays Chakra traces~\cite{chakra2023} (5--15\%); SimAI~\cite{simai2025} models NCCL reductions (1.9\%); VIDUR~\cite{vidur2024} simulates request-level LLM serving; Lumos~\cite{lumos2025} (3.3\%), Echo~\cite{echo2024}, Paleo~\cite{paleo2017}, and other serving tools~\cite{distserve2024,frontier2025,podattention2025,aqua2025,throttllem2025,sailor2025} provide complementary coverage. For edge, nn-Meter~\cite{nnmeter2021} claims $<$1\% but is unverifiable (Section~\ref{sec:eval-results}); LitePred~\cite{litepred2024} achieves 0.7\% across 85 platforms; HELP~\cite{help2021} reaches 1.9\% with 10-sample meta-learning~\cite{esm2025,latencypredictorsnas2024}.
 \section{Evaluation Methodology}
 \label{sec:eval-framework}
 
@@ -1022,7 +1015,7 @@ Future versions should expand to at least 40 scenarios to maintain coverage as t
 \label{sec:unified-pipeline}
 
 No single tool spans kernel execution through distributed training to serving SLAs (Table~\ref{tab:feature-matrix}).
-We propose a five-layer pipeline (Figure~\ref{fig:pipeline-architecture}): (1)~hardware design (Timeloop), (2)~kernel prediction (NeuSight), (3)~\textbf{model composition (CRITICAL GAP---no tool validates this layer)}, (4)~distributed training (ASTRA-sim), and (5)~serving system (VIDUR).
+Figure~\ref{fig:pipeline-architecture} shows a five-layer pipeline: hardware design (Timeloop), kernel prediction (NeuSight), \textbf{model composition (CRITICAL GAP)}, distributed training (ASTRA-sim), and serving (VIDUR).
 
 \begin{figure}[t]
 \centering
@@ -1044,15 +1037,13 @@ We propose a five-layer pipeline (Figure~\ref{fig:pipeline-architecture}): (1)~h
 \label{fig:pipeline-architecture}
 \end{figure}
 
-\textbf{The critical gap} is kernel-to-model composition: NeuSight's 5--9\% kernel MAPE grows to 10--28\% at model level via launch overhead, data movement, and synchronization.
-Realizing this pipeline requires common workload formats, validated composition models, and cross-hardware transfer methods (accuracy degrades $3$--$4\times$ outside training distributions).
+\textbf{Critical gap:} NeuSight's 5--9\% kernel MAPE grows to 10--28\% at model level via launch overhead, data movement, and synchronization---no validated composition model addresses this layer. Realizing the full pipeline requires common workload formats and cross-hardware transfer (accuracy degrades $3$--$4\times$ outside training distributions).
 
 \section{Open Challenges and Future Directions}
 \label{sec:challenges}
 
-Our evaluation exposes six research directions.
+Our evaluation exposes four research directions.
 \textbf{(1)~Composition gap:} Kernel errors of 2--3\% yield 5--12\% model-level error (Figure~\ref{fig:error-composition}; $\sigma_{\text{model}} \approx \sigma_{\text{kernel}} \cdot \sqrt{N}$), yet no validated composition pipeline exists.
-
 \begin{figure}[t]
 \centering
 \resizebox{\columnwidth}{!}{%
@@ -1070,14 +1061,12 @@ Our evaluation exposes six research directions.
 \caption{Error composition: kernel predictions (2--3\%) accumulate to 5--15\% at system level.}
 \label{fig:error-composition}
 \end{figure}
-
 \textbf{(2)~Frontier workloads:} MoE, diffusion~\cite{dynamicreasoning2026}, and dynamic inference lack validated tools; scaling laws~\cite{kaplan2020scaling,hoffmann2022chinchilla,scalinglaws2024,scalinglawguide2025} predict loss but not latency (Figure~\ref{fig:workload-coverage}).
-
 \begin{figure}[t]
 \centering
 \resizebox{\columnwidth}{!}{%
 \begin{tikzpicture}
-\begin{axis}[ybar stacked, bar width=14pt, xlabel={Publication year}, ylabel={Number of tools}, ymin=0, ymax=16, xtick={2016,2018,2020,2022,2024,2026}, xticklabels={2016--17,2018--19,2020--21,2022--23,2024--25,2026}, xticklabel style={font=\scriptsize}, yticklabel style={font=\scriptsize}, xlabel style={font=\small}, ylabel style={font=\small}, legend style={at={(0.02,0.98)}, anchor=north west, font=\tiny, draw=none, fill=white, fill opacity=0.9, text opacity=1, legend columns=2}, legend cell align={left}, height=4.5cm, width=8.5cm, enlarge x limits={abs=0.8cm}]
+\begin{axis}[ybar stacked, bar width=14pt, xlabel={Publication year}, ylabel={Number of tools}, ymin=0, ymax=16, xtick={2016,2018,2020,2022,2024,2026}, xticklabels={2016--17,2018--19,2020--21,2022--23,2024--25,2026}, xticklabel style={font=\scriptsize}, yticklabel style={font=\scriptsize}, xlabel style={font=\small}, ylabel style={font=\small}, legend style={at={(0.02,0.98)}, anchor=north west, font=\tiny, draw=none, fill=white, fill opacity=0.9, text opacity=1, legend columns=2}, legend cell align={left}, height=3.5cm, width=8.5cm, enlarge x limits={abs=0.8cm}]
 \addplot[fill=blue!50, draw=blue!70] coordinates {(2016,2) (2018,2) (2020,4) (2022,3) (2024,2) (2026,0)};
 \addplot[fill=orange!50, draw=orange!70] coordinates {(2016,0) (2018,1) (2020,0) (2022,2) (2024,3) (2026,0)};
 \addplot[fill=red!50, draw=red!70] coordinates {(2016,0) (2018,0) (2020,1) (2022,1) (2024,8) (2026,2)};
@@ -1089,9 +1078,8 @@ Our evaluation exposes six research directions.
 \caption{Workload coverage by publication period. MoE and diffusion models remain uncharacterized.}
 \label{fig:workload-coverage}
 \end{figure}
-
-\textbf{(3)~Hardware transfer and network fidelity:} Cross-family transfer (GPU$\rightarrow$TPU$\rightarrow$PIM~\cite{upimulator2024,attacc2024,neupims2024,paise2025}) remains unsolved, and current tools~\cite{astrasim2023,triosim2025} use analytical network abstractions omitting congestion captured only by NS-3~\cite{ns3_2010}.
-\textbf{(4)~Standardized evaluation and temporal stability:} No MLPerf~\cite{mlperf_training2020,mlperf_inference2020} equivalent exists for prediction tools---the community needs common benchmarks, portable formats (ONNX, Chakra~\cite{chakra2023}), Docker-first deployment, and continuous validation~\cite{mlperfpower2025} (nn-Meter's dependency rot exemplifies model invalidation by software evolution~\cite{flashattention2022}).
+\textbf{(3)~Hardware transfer and network fidelity:} Cross-family transfer (GPU$\rightarrow$TPU$\rightarrow$PIM~\cite{upimulator2024,attacc2024,neupims2024,paise2025}) remains unsolved; tools~\cite{astrasim2023,triosim2025} use analytical network abstractions omitting congestion modeled only by NS-3~\cite{ns3_2010}.
+\textbf{(4)~Standardized evaluation:} No MLPerf~\cite{mlperf_training2020,mlperf_inference2020} equivalent exists for prediction tools; the community needs common benchmarks, portable formats (ONNX, Chakra~\cite{chakra2023}), and continuous validation~\cite{mlperfpower2025} (nn-Meter's dependency rot exemplifies model invalidation by software evolution~\cite{flashattention2022}).
 
 \section{Conclusion}
 \label{sec:conclusion}


### PR DESCRIPTION
## Summary
- Cut 12 raw lines from non-eval sections (1105→1093)
- Switched taxonomy and survey tables from \small to \footnotesize
- Compacted 4 TikZ figures: tool-architecture, abstraction-levels, timeline, workload-coverage bar chart
- Removed blank lines between section items in Open Challenges and Taxonomy
- Tightened prose in Background, Survey Methodology, Survey of Approaches, Introduction
- Added enumitem package for compact itemize in Introduction

## Changes by section
- **Introduction**: Added [noitemsep,topsep=2pt] to itemize
- **Survey Methodology**: Tightened 4 lines → shorter sentences
- **Background**: Merged paragraph, shortened
- **Taxonomy**: Removed blank lines, table to footnotesize, compacted 2 TikZ figures
- **Survey of Approaches**: Table to footnotesize, merged paragraphs
- **Unified Pipeline**: Merged prose into 1 paragraph
- **Open Challenges**: Removed blank lines between items, compacted workload bar chart height 4.5→3.5cm

## Test plan
- [ ] Verify LaTeX compiles without errors
- [ ] Check page count reduction