### PR TITLE
Fifth compression pass: global spacing reductions

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -45,6 +45,15 @@
 \usepgfplotslibrary{groupplots}
 \usetikzlibrary{plotmarks}
 
+% Global spacing reductions for page limit
+\setlength{\textfloatsep}{5pt plus 1pt minus 2pt}
+\setlength{\floatsep}{5pt plus 1pt minus 2pt}
+\setlength{\intextsep}{5pt plus 1pt minus 2pt}
+\setlength{\dbltextfloatsep}{5pt plus 1pt minus 2pt}
+\setlength{\dblfloatsep}{5pt plus 1pt minus 2pt}
+\setlength{\abovecaptionskip}{3pt}
+\setlength{\belowcaptionskip}{2pt}
+
 % Custom commands
 \newcommand{\todo}[1]{\textcolor{red}{[TODO: #1]}}
 


### PR DESCRIPTION
## Summary
- Reduced \textfloatsep, \floatsep, \intextsep, \dbltextfloatsep, \dblfloatsep to 5pt
- Reduced \abovecaptionskip to 3pt, \belowcaptionskip to 2pt
- This globally reduces space around all figures and tables, saving ~0.5-1 page

## Expected impact
- Space above/below figures reduced from LaTeX default (~12pt) to 5pt
- Caption spacing reduced from default (~10pt) to 3/2pt
- Should reduce rendered body pages from ~12 to ~11.5 or below

## Test plan
- [ ] Verify LaTeX compiles without errors
- [ ] Check page count